### PR TITLE
DRAFT: Adjust the avg buy price calculation

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "@openzeppelin/truffle-upgrades": "^1.7.0",
         "@particle-network/aa": "^1.2.0",
         "@reality.eth/reality-eth-lib": "^3.2.10",
+        "@types/mocha": "^10.0.10",
         "axios": "^0.24.0",
         "babel-cli": "^6.26.0",
         "babel-plugin-transform-runtime": "^6.23.0",

--- a/tests/getAverageOutcomeBuyPrice.test.ts
+++ b/tests/getAverageOutcomeBuyPrice.test.ts
@@ -55,6 +55,7 @@ function getAverageOutcomeBuyPriceV2({ events, marketId, outcomeId }) {
 
 const testDatasets = [
   {
+    name: "Double buy",
     events: [
       { action: "Buy", marketId: 1, outcomeId: 1, shares: 100, value: 500 }, // local avg = 5
       { action: "Buy", marketId: 1, outcomeId: 1, shares: 50, value: 300 }, // local avg = 6, new avg formula = (5 * 100 + 6 * 50) / 150 = 5.33
@@ -63,6 +64,7 @@ const testDatasets = [
   },
 
   {
+    name: "Buy, partial sell, buy",
     events: [
       { action: "Buy", marketId: 1, outcomeId: 1, shares: 100, value: 500 }, // local avg = 5
       { action: "Sell", marketId: 1, outcomeId: 1, shares: 50, value: 200 }, // sell, avg = 5
@@ -72,6 +74,7 @@ const testDatasets = [
   },
 
   {
+    name: "Simple sell",
     events: [
       { action: "Sell", marketId: 1, outcomeId: 1, shares: 50, value: 200 }, // sell, avg = 0
     ],
@@ -79,6 +82,7 @@ const testDatasets = [
   },
 
   {
+    name: "Buy, sell, buy, sell",
     events: [
       { action: "Buy", marketId: 1, outcomeId: 1, shares: 200, value: 800 }, // local avg = 4, avg = 4
       { action: "Sell", marketId: 1, outcomeId: 1, shares: 50, value: 200 }, // sell, avg = 4
@@ -89,6 +93,17 @@ const testDatasets = [
   },
 
   {
+    name: "Buy, sell everything, buy",
+    events: [
+      { action: "Buy", marketId: 1, outcomeId: 1, shares: 100, value: 500 }, // local avg = 5
+      { action: "Sell", marketId: 1, outcomeId: 1, shares: 100, value: 500 }, // sell everything, avg = 0
+      { action: "Buy", marketId: 1, outcomeId: 1, shares: 50, value: 300 }, // local avg = 6, avg = 6
+    ],
+    expected: 6,
+  },
+
+  {
+    name: "No events",
     events: [],
     expected: 0,
   },
@@ -97,7 +112,9 @@ const testDatasets = [
 // 2. Покупки и частичная продажа
 describe("getAverageOutcomeBuyPriceV1", () => {
   testDatasets.forEach((dataset, index) => {
-    it(`should return correct average for dataset ${index + 1}`, () => {
+    it(`should return correct average for dataset #${index + 1} "${
+      dataset.name
+    }"`, () => {
       const result = getAverageOutcomeBuyPriceV1({
         events: dataset.events,
         marketId: 1,
@@ -110,7 +127,9 @@ describe("getAverageOutcomeBuyPriceV1", () => {
 
 describe("getAverageOutcomeBuyPriceV2", () => {
   testDatasets.forEach((dataset, index) => {
-    it(`should return correct average for dataset ${index + 1}`, () => {
+    it(`should return correct average for dataset #${index + 1} "${
+      dataset.name
+    }"`, () => {
       const result = getAverageOutcomeBuyPriceV2({
         events: dataset.events,
         marketId: 1,
@@ -123,7 +142,9 @@ describe("getAverageOutcomeBuyPriceV2", () => {
 
 describe("Comparison of V1 and V2", () => {
   testDatasets.forEach((dataset, index) => {
-    it(`should return the same average for dataset ${index + 1}`, () => {
+    it(`should return the same average for dataset #${index + 1} "${
+      dataset.name
+    }"`, () => {
       const resultV1 = getAverageOutcomeBuyPriceV1({
         events: dataset.events,
         marketId: 1,

--- a/tests/getAverageOutcomeBuyPrice.test.ts
+++ b/tests/getAverageOutcomeBuyPrice.test.ts
@@ -1,0 +1,140 @@
+import { expect } from "chai";
+import "mocha";
+
+/**
+ * The old implementation of the function
+ */
+function getAverageOutcomeBuyPriceV1({ events, marketId, outcomeId }) {
+  // filtering by marketId + outcomeId + buy action
+  events = events.filter((event) => {
+    return (
+      event.action === "Buy" &&
+      event.marketId === marketId &&
+      event.outcomeId === outcomeId
+    );
+  });
+
+  if (events.length === 0) return 0;
+
+  const totalShares = events
+    .map((item) => item.shares)
+    .reduce((prev, next) => prev + next);
+  const totalAmount = events
+    .map((item) => item.value)
+    .reduce((prev, next) => prev + next);
+
+  return totalAmount / totalShares;
+}
+
+/**
+ * The new implementation of the function
+ * The key difference is that we calculate the proportion of the shares that were sold
+ * and adjust the totalShares and totalAmount accordingly
+ */
+function getAverageOutcomeBuyPriceV2({ events, marketId, outcomeId }) {
+  let totalShares = 0;
+  let totalAmount = 0;
+
+  events.forEach((event) => {
+    if (event.marketId === marketId && event.outcomeId === outcomeId) {
+      if (event.action === "Buy") {
+        totalShares += event.shares;
+        totalAmount += event.value;
+      } else if (event.action === "Sell") {
+        const proportion = event.shares / totalShares;
+        totalShares -= event.shares;
+        totalAmount *= 1 - proportion;
+      }
+    }
+  });
+
+  return totalShares === totalShares && totalAmount
+    ? totalAmount / totalShares
+    : 0;
+}
+
+const testDatasets = [
+  {
+    events: [
+      { action: "Buy", marketId: 1, outcomeId: 1, shares: 100, value: 500 }, // local avg = 5
+      { action: "Buy", marketId: 1, outcomeId: 1, shares: 50, value: 300 }, // local avg = 6, new avg formula = (5 * 100 + 6 * 50) / 150 = 5.33
+    ],
+    expected: 5.33,
+  },
+
+  {
+    events: [
+      { action: "Buy", marketId: 1, outcomeId: 1, shares: 100, value: 500 }, // local avg = 5
+      { action: "Sell", marketId: 1, outcomeId: 1, shares: 50, value: 200 }, // sell, avg = 5
+      { action: "Buy", marketId: 1, outcomeId: 1, shares: 50, value: 500 }, // local avg = 10, new avg formula = (5 * 50 + 10 * 50) / 100 = 7.5
+    ],
+    expected: 7.5,
+  },
+
+  {
+    events: [
+      { action: "Sell", marketId: 1, outcomeId: 1, shares: 50, value: 200 }, // sell, avg = 0
+    ],
+    expected: 0,
+  },
+
+  {
+    events: [
+      { action: "Buy", marketId: 1, outcomeId: 1, shares: 200, value: 800 }, // local avg = 4, avg = 4
+      { action: "Sell", marketId: 1, outcomeId: 1, shares: 50, value: 200 }, // sell, avg = 4
+      { action: "Buy", marketId: 1, outcomeId: 1, shares: 100, value: 600 }, // local avg = 6, new avg formula = (4 * 150 + 6 * 100) / 250 = 4.8
+      { action: "Sell", marketId: 1, outcomeId: 1, shares: 100, value: 400 }, // sell, avg = 4.8
+    ],
+    expected: 4.8,
+  },
+
+  {
+    events: [],
+    expected: 0,
+  },
+];
+
+// 2. Покупки и частичная продажа
+describe("getAverageOutcomeBuyPriceV1", () => {
+  testDatasets.forEach((dataset, index) => {
+    it(`should return correct average for dataset ${index + 1}`, () => {
+      const result = getAverageOutcomeBuyPriceV1({
+        events: dataset.events,
+        marketId: 1,
+        outcomeId: 1,
+      });
+      expect(result).to.be.closeTo(dataset.expected, 0.01);
+    });
+  });
+});
+
+describe("getAverageOutcomeBuyPriceV2", () => {
+  testDatasets.forEach((dataset, index) => {
+    it(`should return correct average for dataset ${index + 1}`, () => {
+      const result = getAverageOutcomeBuyPriceV2({
+        events: dataset.events,
+        marketId: 1,
+        outcomeId: 1,
+      });
+      expect(result).to.be.closeTo(dataset.expected, 0.01);
+    });
+  });
+});
+
+describe("Comparison of V1 and V2", () => {
+  testDatasets.forEach((dataset, index) => {
+    it(`should return the same average for dataset ${index + 1}`, () => {
+      const resultV1 = getAverageOutcomeBuyPriceV1({
+        events: dataset.events,
+        marketId: 1,
+        outcomeId: 1,
+      });
+      const resultV2 = getAverageOutcomeBuyPriceV2({
+        events: dataset.events,
+        marketId: 1,
+        outcomeId: 1,
+      });
+      expect(resultV1).to.be.closeTo(resultV2, 0.01);
+    });
+  });
+});


### PR DESCRIPTION
@rsmarques Here's my suggestion for the new `getAverageOutcomeBuyPrice` method.

I didn't add it straight to the controller because I just wanted to demonstrate the approach and get your feedback.

I added some scenarios that represent the challenges we currently have (e.g., buy, partial sell, buy again at a new price). Feel free to add more real-world datasets

## The updated method
```ts
/**
 * The new implementation of the function
 * The key difference is that we calculate the proportion of the shares that were sold
 * and adjust the totalShares and totalAmount accordingly
 */
function getAverageOutcomeBuyPriceV2({ events, marketId, outcomeId }) {
  let totalShares = 0;
  let totalAmount = 0;

  events.forEach((event) => {
    if (event.marketId === marketId && event.outcomeId === outcomeId) {
      if (event.action === "Buy") {
        totalShares += event.shares;
        totalAmount += event.value;
      } else if (event.action === "Sell") {
        const proportion = event.shares / totalShares;
        totalShares -= event.shares;
        totalAmount *= 1 - proportion;
      }
    }
  });

  return totalShares === totalShares && totalAmount
    ? totalAmount / totalShares
    : 0;
}
```

## Run test
```bash
yarn mocha tests/getAverageOutcomeBuyPrice.test.ts --require babel-core/register --require babel-polyfill;
```

I've kept the v1 method for comparison:

```bash

  getAverageOutcomeBuyPriceV1
    ✓ should return correct average for dataset #1 "Double buy"
    1) should return correct average for dataset #2 "Buy, partial sell, buy"
    ✓ should return correct average for dataset #3 "Simple sell"
    2) should return correct average for dataset #4 "Buy, sell, buy, sell"
    3) should return correct average for dataset #5 "Buy, sell everything, buy"
    ✓ should return correct average for dataset #6 "No events"

  getAverageOutcomeBuyPriceV2
    ✓ should return correct average for dataset #1 "Double buy"
    ✓ should return correct average for dataset #2 "Buy, partial sell, buy"
    ✓ should return correct average for dataset #3 "Simple sell"
    ✓ should return correct average for dataset #4 "Buy, sell, buy, sell"
    ✓ should return correct average for dataset #5 "Buy, sell everything, buy"
    ✓ should return correct average for dataset #6 "No events"

  Comparison of V1 and V2
    ✓ should return the same average for dataset #1 "Double buy"
    4) should return the same average for dataset #2 "Buy, partial sell, buy"
    ✓ should return the same average for dataset #3 "Simple sell"
    5) should return the same average for dataset #4 "Buy, sell, buy, sell"
    6) should return the same average for dataset #5 "Buy, sell everything, buy"
    ✓ should return the same average for dataset #6 "No events"
```


