### PR TITLE
Eng 2657 add negrisk cross market sell merge

### DIFF
--- a/contracts/MyriadCTFExchange.sol
+++ b/contracts/MyriadCTFExchange.sol
@@ -28,6 +28,7 @@ interface IFeeModule {
 /// @dev Minimal interface for the NegRiskAdapter, used by cross-market matching.
 interface INegRiskAdapter {
   function mintAllYesTokens(bytes32 eventId, uint256 amount, address recipient) external;
+  function mergeAllYesTokens(bytes32 eventId, uint256 amount) external;
   function getEventOutcomeCount(bytes32 eventId) external view returns (uint256);
 }
 
@@ -325,33 +326,8 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
       require(orders.length == expectedCount, "must match all outcomes");
     }
 
-    uint256 priceSum;
-    bytes32[] memory orderHashes = new bytes32[](orders.length);
-    uint256[] memory currentFilled = new uint256[](orders.length);
-
-    for (uint256 i = 0; i < orders.length; i++) {
-      Order calldata order = orders[i];
-      require(order.side == Side.Buy, "not buy");
-      require(order.outcomeId == Outcomes.YES, "not YES");
-      require(order.price > 0 && order.price <= ONE, "bad price");
-      require(_manager.getEventId(order.marketId) == eventId, "event mismatch");
-      require(_manager.isNegRisk(order.marketId), "not neg risk");
-
-      _requireMarketOpen(order.marketId);
-      _validateOrder(order, signatures[i]);
-
-      bytes32 h = hashOrder(order);
-      orderHashes[i] = h;
-      currentFilled[i] = filledAmounts[h];
-      require(currentFilled[i] + fillAmount <= order.amount, "overfill");
-      require(order.minFillAmount == 0 || fillAmount >= order.minFillAmount, "below min fill");
-
-      for (uint256 j = 0; j < i; j++) {
-        require(order.marketId != orders[j].marketId, "dup market");
-      }
-
-      priceSum += order.price;
-    }
+    (bytes32[] memory orderHashes, uint256[] memory currentFilled, uint256 priceSum) =
+      _validateCrossMarketOrders(orders, signatures, fillAmount, eventId, Side.Buy);
 
     require(priceSum >= ONE, "price sum < 1");
 
@@ -409,6 +385,84 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     uint256 surplus = totalNotional - fillAmount;
     uint256 toFeeModule = totalFees + surplus;
     if (toFeeModule > 0) {
+      collateral.safeTransfer(address(_feeModule), toFeeModule);
+      _feeModule.accrueFees(address(collateral), toFeeModule);
+    }
+    if (surplus > 0) {
+      emit SurplusCollected(eventId, surplus);
+    }
+  }
+
+  /// @notice Reverse of matchCrossMarketOrders: match SELL YES orders across
+  ///         different outcome markets in the same neg risk event.
+  ///         All orders must be SELL side, outcome 0 (YES), for distinct markets
+  ///         belonging to the same event. Prices must sum to <= ONE.
+  ///         YES tokens are collected from sellers, merged via NegRiskAdapter
+  ///         (using the adapter's held NO tokens), and the resulting collateral
+  ///         is distributed as proceeds to each seller.
+  function mergeCrossMarketOrders(
+    Order[] calldata orders,
+    bytes[] calldata signatures,
+    uint256 fillAmount
+  ) external whenNotPaused nonReentrant {
+    require(registry.hasRole(registry.OPERATOR_ROLE(), msg.sender), "not operator");
+
+    address _adapter = negRiskAdapter;
+    require(_adapter != address(0), "no adapter");
+    require(orders.length >= 2, "need >= 2 orders");
+    require(signatures.length == orders.length, "sig count");
+    require(fillAmount > 0, "fill 0");
+
+    IMyriadMarketManager _manager = manager;
+    ConditionalTokens _ct = conditionalTokens;
+    IFeeModule _feeModule = IFeeModule(feeModule);
+
+    bytes32 eventId = _manager.getEventId(orders[0].marketId);
+    require(eventId != bytes32(0), "not neg risk");
+
+    {
+      uint256 expectedCount = INegRiskAdapter(_adapter).getEventOutcomeCount(eventId);
+      require(orders.length == expectedCount, "must match all outcomes");
+    }
+
+    (bytes32[] memory orderHashes, uint256[] memory currentFilled, uint256 priceSum) =
+      _validateCrossMarketOrders(orders, signatures, fillAmount, eventId, Side.Sell);
+
+    require(priceSum <= ONE, "price sum > 1");
+
+    // Check all YES token balances, then collect tokens to adapter.
+    for (uint256 i = 0; i < orders.length; i++) {
+      uint256 yesTokenId = _ct.getTokenId(orders[i].marketId, Outcomes.YES);
+      _checkTokenBalance(orders[i].trader, yesTokenId, fillAmount);
+    }
+
+    for (uint256 i = 0; i < orders.length; i++) {
+      uint256 yesTokenId = _ct.getTokenId(orders[i].marketId, Outcomes.YES);
+      _ct.safeTransferFrom(orders[i].trader, _adapter, yesTokenId, fillAmount, "");
+    }
+
+    INegRiskAdapter(_adapter).mergeAllYesTokens(eventId, fillAmount);
+
+    (uint256 totalNotional, uint256 totalFees) = _distributeMergeProceeds(orders, fillAmount, _feeModule, _manager);
+
+    // Update fill amounts and emit events.
+    for (uint256 i = 0; i < orders.length; i++) {
+      uint256 newFill = currentFilled[i] + fillAmount;
+      filledAmounts[orderHashes[i]] = newFill;
+
+      if (minOrderAmount > 0) {
+        uint256 remaining = orders[i].amount - newFill;
+        require(remaining == 0 || remaining >= minOrderAmount, "dust remainder");
+      }
+
+      emit CrossMarketOrderFilled(orderHashes[i], eventId, orders[i].marketId, fillAmount, newFill);
+    }
+
+    // Surplus (priceSum < ONE) + fees to feeModule.
+    uint256 surplus = fillAmount - totalNotional;
+    uint256 toFeeModule = totalFees + surplus;
+    if (toFeeModule > 0) {
+      IERC20 collateral = _manager.getMarketCollateral(orders[0].marketId);
       collateral.safeTransfer(address(_feeModule), toFeeModule);
       _feeModule.accrueFees(address(collateral), toFeeModule);
     }
@@ -843,6 +897,73 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
 
     if (totalProtocolFees > 0) {
       collateral.safeTransfer(feeModule, totalProtocolFees);
+    }
+  }
+
+  /// @dev Shared validation for cross-market orders (BUY mint or SELL merge).
+  function _validateCrossMarketOrders(
+    Order[] calldata orders,
+    bytes[] calldata signatures,
+    uint256 fillAmount,
+    bytes32 eventId,
+    Side expectedSide
+  ) internal view returns (bytes32[] memory, uint256[] memory, uint256) {
+    uint256 n = orders.length;
+    bytes32[] memory hashes = new bytes32[](n);
+    uint256[] memory filled = new uint256[](n);
+    uint256 priceSum;
+
+    for (uint256 i = 0; i < n; i++) {
+      require(orders[i].side == expectedSide, expectedSide == Side.Buy ? "not buy" : "not sell");
+      require(orders[i].outcomeId == Outcomes.YES, "not YES");
+      require(orders[i].price > 0 && orders[i].price <= ONE, "bad price");
+      require(manager.getEventId(orders[i].marketId) == eventId, "event mismatch");
+      require(manager.isNegRisk(orders[i].marketId), "not neg risk");
+
+      _requireMarketOpen(orders[i].marketId);
+      _validateOrder(orders[i], signatures[i]);
+
+      hashes[i] = hashOrder(orders[i]);
+      filled[i] = filledAmounts[hashes[i]];
+      require(filled[i] + fillAmount <= orders[i].amount, "overfill");
+      require(orders[i].minFillAmount == 0 || fillAmount >= orders[i].minFillAmount, "below min fill");
+
+      for (uint256 j = 0; j < i; j++) {
+        require(orders[i].marketId != orders[j].marketId, "dup market");
+      }
+
+      priceSum += orders[i].price;
+    }
+
+    return (hashes, filled, priceSum);
+  }
+
+  /// @dev Distribute merge proceeds to sellers: each gets (notional - fee).
+  function _distributeMergeProceeds(
+    Order[] calldata orders,
+    uint256 fillAmount,
+    IFeeModule _feeModule,
+    IMyriadMarketManager _manager
+  ) internal returns (uint256 totalNotional, uint256 totalFees) {
+    IERC20 collateral = _manager.getMarketCollateral(orders[0].marketId);
+    uint256 takerIdx = orders.length - 1;
+
+    for (uint256 i = 0; i < orders.length; i++) {
+      uint256 notional = (fillAmount * orders[i].price) / ONE;
+      require(notional > 0, "notional 0");
+      totalNotional += notional;
+
+      uint256 fee;
+      if (i == takerIdx) {
+        (, uint16 takerBps) = _feeModule.getFeesAtPrice(orders[i].marketId, orders[i].price);
+        fee = (notional * takerBps) / BPS;
+      } else {
+        (uint16 makerBps, ) = _feeModule.getFeesAtPrice(orders[i].marketId, orders[i].price);
+        fee = (notional * makerBps) / BPS;
+      }
+      totalFees += fee;
+
+      collateral.safeTransfer(orders[i].trader, notional - fee);
     }
   }
 

--- a/contracts/NegRiskAdapter.sol
+++ b/contracts/NegRiskAdapter.sol
@@ -60,6 +60,7 @@ contract NegRiskAdapter is ReentrancyGuardTransient, ERC1155Holder {
   event PositionsMerged(bytes32 indexed eventId, uint256 outcomeIndex, address indexed user, uint256 amount);
   event PositionsConverted(bytes32 indexed eventId, uint256 noOutcomeIndex, address indexed user, uint256 amount);
   event AllYesTokensMinted(bytes32 indexed eventId, address indexed recipient, uint256 amount);
+  event AllYesTokensMerged(bytes32 indexed eventId, address indexed sender, uint256 amount);
   event NOPositionsRedeemed(bytes32 indexed eventId, uint256 wcolRecovered, uint256 wcolBurned, uint256 excessToTreasury);
   event TreasuryUpdated(address indexed oldTreasury, address indexed newTreasury);
   event ExchangeUpdated(address indexed oldExchange, address indexed newExchange);
@@ -305,6 +306,38 @@ contract NegRiskAdapter is ReentrancyGuardTransient, ERC1155Holder {
     }
 
     emit AllYesTokensMinted(eventId, recipient, amount);
+  }
+
+  /// @notice Reverse of mintAllYesTokens: merge YES tokens for ALL outcomes
+  ///         back to wcol. The caller (exchange) must have already transferred
+  ///         `amount` YES tokens for every outcome to this contract.
+  ///         Adapter merges each market (burns YES + its held NO), burns the
+  ///         adapter-minted wcol portion, and returns `amount` wcol to caller.
+  /// @param eventId The event identifier.
+  /// @param amount Number of shares per outcome to merge.
+  function mergeAllYesTokens(
+    bytes32 eventId,
+    uint256 amount
+  ) external nonReentrant {
+    require(msg.sender == exchange, "only exchange");
+    Event storage evt = _events[eventId];
+    require(evt.outcomeCount > 0, "event !exist");
+    require(!evt.resolved, "event resolved");
+    require(amount > 0, "amount 0");
+
+    uint256 n = evt.outcomeCount;
+
+    for (uint256 i = 0; i < n; i++) {
+      conditionalTokens.mergePositions(evt.marketIds[i], amount);
+    }
+
+    uint256 wcolToBurn = (n - 1) * amount;
+    mintedWcolPerEvent[eventId] -= wcolToBurn;
+    wcol.adapterBurn(address(this), wcolToBurn);
+
+    IERC20(address(wcol)).safeTransfer(msg.sender, amount);
+
+    emit AllYesTokensMerged(eventId, msg.sender, amount);
   }
 
   // ─── Resolution ──────────────────────────────────────────────────────

--- a/test/NegRiskAdapter.t.sol
+++ b/test/NegRiskAdapter.t.sol
@@ -970,6 +970,521 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
   }
 
   // =========================================================================
+  // Cross-market merge (SELL YES)
+  // =========================================================================
+
+  function _setupBuyThenSell(
+    uint256[] memory marketIds,
+    uint256 amount
+  ) internal returns (MyriadCTFExchange.Order[] memory buyOrders) {
+    for (uint256 i = 0; i < 3; i++) _setUniformFees(marketIds[i], 100, 200);
+
+    uint256 fundAmount = 500 ether;
+    for (uint256 i = 0; i < 3; i++) {
+      address user = i == 0 ? alice : (i == 1 ? bob : charlie);
+      collateral.mint(user, fundAmount);
+      vm.startPrank(user);
+      collateral.approve(address(wcol), fundAmount);
+      wcol.wrap(fundAmount);
+      IERC20(address(wcol)).approve(address(exchange), type(uint256).max);
+      conditionalTokens.setApprovalForAll(address(exchange), true);
+      vm.stopPrank();
+    }
+
+    uint256 price0 = (45 * ONE) / 100;
+    uint256 price1 = (35 * ONE) / 100;
+    uint256 price2 = (20 * ONE) / 100;
+
+    buyOrders = new MyriadCTFExchange.Order[](3);
+    buyOrders[0] = _buildOrder(alice, marketIds[0], Outcomes.YES, MyriadCTFExchange.Side.Buy, amount, price0, 100);
+    buyOrders[1] = _buildOrder(bob, marketIds[1], Outcomes.YES, MyriadCTFExchange.Side.Buy, amount, price1, 101);
+    buyOrders[2] = _buildOrder(charlie, marketIds[2], Outcomes.YES, MyriadCTFExchange.Side.Buy, amount, price2, 102);
+
+    bytes[] memory sigs = new bytes[](3);
+    sigs[0] = _signOrder(buyOrders[0], alicePk);
+    sigs[1] = _signOrder(buyOrders[1], bobPk);
+    sigs[2] = _signOrder(buyOrders[2], charliePk);
+
+    exchange.matchCrossMarketOrders(buyOrders, sigs, amount);
+  }
+
+  function testMergeCrossMarketMatch() public {
+    (, uint256[] memory marketIds) = _createThreeOutcomeEvent();
+    uint256 amount = 100 ether;
+
+    _setupBuyThenSell(marketIds, amount);
+
+    uint256 price0 = (45 * ONE) / 100;
+    uint256 price1 = (35 * ONE) / 100;
+    uint256 price2 = (20 * ONE) / 100;
+
+    MyriadCTFExchange.Order[] memory sellOrders = new MyriadCTFExchange.Order[](3);
+    sellOrders[0] = _buildOrder(alice, marketIds[0], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price0, 200);
+    sellOrders[1] = _buildOrder(bob, marketIds[1], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price1, 201);
+    sellOrders[2] = _buildOrder(charlie, marketIds[2], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price2, 202);
+
+    bytes[] memory sigs = new bytes[](3);
+    sigs[0] = _signOrder(sellOrders[0], alicePk);
+    sigs[1] = _signOrder(sellOrders[1], bobPk);
+    sigs[2] = _signOrder(sellOrders[2], charliePk);
+
+    exchange.mergeCrossMarketOrders(sellOrders, sigs, amount);
+
+    assertEq(conditionalTokens.balanceOf(alice, conditionalTokens.getTokenId(marketIds[0], Outcomes.YES)), 0);
+    assertEq(conditionalTokens.balanceOf(bob, conditionalTokens.getTokenId(marketIds[1], Outcomes.YES)), 0);
+    assertEq(conditionalTokens.balanceOf(charlie, conditionalTokens.getTokenId(marketIds[2], Outcomes.YES)), 0);
+
+    bytes32 hash0 = exchange.hashOrder(sellOrders[0]);
+    assertEq(exchange.filledAmounts(hash0), amount);
+  }
+
+  function testMergeCrossMarketPriceSumOver1Reverts() public {
+    (, uint256[] memory marketIds) = _createThreeOutcomeEvent();
+    uint256 amount = 100 ether;
+
+    _setupBuyThenSell(marketIds, amount);
+
+    uint256 price0 = (45 * ONE) / 100;
+    uint256 price1 = (35 * ONE) / 100;
+    uint256 price2 = (21 * ONE) / 100;
+
+    MyriadCTFExchange.Order[] memory sellOrders = new MyriadCTFExchange.Order[](3);
+    sellOrders[0] = _buildOrder(alice, marketIds[0], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price0, 300);
+    sellOrders[1] = _buildOrder(bob, marketIds[1], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price1, 301);
+    sellOrders[2] = _buildOrder(charlie, marketIds[2], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price2, 302);
+
+    bytes[] memory sigs = new bytes[](3);
+    sigs[0] = _signOrder(sellOrders[0], alicePk);
+    sigs[1] = _signOrder(sellOrders[1], bobPk);
+    sigs[2] = _signOrder(sellOrders[2], charliePk);
+
+    vm.expectRevert("price sum > 1");
+    exchange.mergeCrossMarketOrders(sellOrders, sigs, amount);
+  }
+
+  function testMergeCrossMarketNotSellReverts() public {
+    (, uint256[] memory marketIds) = _createThreeOutcomeEvent();
+    uint256 amount = 100 ether;
+
+    _setupBuyThenSell(marketIds, amount);
+
+    uint256 price0 = (45 * ONE) / 100;
+    uint256 price1 = (35 * ONE) / 100;
+    uint256 price2 = (20 * ONE) / 100;
+
+    MyriadCTFExchange.Order[] memory sellOrders = new MyriadCTFExchange.Order[](3);
+    sellOrders[0] = _buildOrder(alice, marketIds[0], Outcomes.YES, MyriadCTFExchange.Side.Buy, amount, price0, 400);
+    sellOrders[1] = _buildOrder(bob, marketIds[1], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price1, 401);
+    sellOrders[2] = _buildOrder(charlie, marketIds[2], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price2, 402);
+
+    bytes[] memory sigs = new bytes[](3);
+    sigs[0] = _signOrder(sellOrders[0], alicePk);
+    sigs[1] = _signOrder(sellOrders[1], bobPk);
+    sigs[2] = _signOrder(sellOrders[2], charliePk);
+
+    vm.expectRevert("not sell");
+    exchange.mergeCrossMarketOrders(sellOrders, sigs, amount);
+  }
+
+  function testMergeCrossMarketInsufficientTokensReverts() public {
+    (, uint256[] memory marketIds) = _createThreeOutcomeEvent();
+    uint256 amount = 100 ether;
+
+    _setupBuyThenSell(marketIds, amount);
+
+    uint256 price0 = (45 * ONE) / 100;
+    uint256 price1 = (35 * ONE) / 100;
+    uint256 price2 = (20 * ONE) / 100;
+
+    // Transfer away bob's YES tokens so he can't sell
+    uint256 bobTokenId = conditionalTokens.getTokenId(marketIds[1], Outcomes.YES);
+    vm.prank(bob);
+    conditionalTokens.safeTransferFrom(bob, treasury, bobTokenId, amount, "");
+
+    MyriadCTFExchange.Order[] memory sellOrders = new MyriadCTFExchange.Order[](3);
+    sellOrders[0] = _buildOrder(alice, marketIds[0], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price0, 500);
+    sellOrders[1] = _buildOrder(bob, marketIds[1], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price1, 501);
+    sellOrders[2] = _buildOrder(charlie, marketIds[2], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price2, 502);
+
+    bytes[] memory sigs = new bytes[](3);
+    sigs[0] = _signOrder(sellOrders[0], alicePk);
+    sigs[1] = _signOrder(sellOrders[1], bobPk);
+    sigs[2] = _signOrder(sellOrders[2], charliePk);
+
+    vm.expectRevert("insufficient tokens");
+    exchange.mergeCrossMarketOrders(sellOrders, sigs, amount);
+  }
+
+  function testMergeCrossMarketFeesCollected() public {
+    (, uint256[] memory marketIds) = _createThreeOutcomeEvent();
+    uint256 amount = 100 ether;
+
+    _setupBuyThenSell(marketIds, amount);
+
+    uint256 price0 = (45 * ONE) / 100;
+    uint256 price1 = (35 * ONE) / 100;
+    uint256 price2 = (20 * ONE) / 100;
+
+    MyriadCTFExchange.Order[] memory sellOrders = new MyriadCTFExchange.Order[](3);
+    sellOrders[0] = _buildOrder(alice, marketIds[0], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price0, 600);
+    sellOrders[1] = _buildOrder(bob, marketIds[1], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price1, 601);
+    sellOrders[2] = _buildOrder(charlie, marketIds[2], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price2, 602);
+
+    bytes[] memory sigs = new bytes[](3);
+    sigs[0] = _signOrder(sellOrders[0], alicePk);
+    sigs[1] = _signOrder(sellOrders[1], bobPk);
+    sigs[2] = _signOrder(sellOrders[2], charliePk);
+
+    uint256 feeModuleBefore = wcol.balanceOf(address(feeModule));
+
+    exchange.mergeCrossMarketOrders(sellOrders, sigs, amount);
+
+    uint256 feeModuleAfter = wcol.balanceOf(address(feeModule));
+    assertTrue(feeModuleAfter > feeModuleBefore, "fees should be collected");
+  }
+
+  function testMergeCrossMarketSurplus() public {
+    (, uint256[] memory marketIds) = _createThreeOutcomeEvent();
+    uint256 amount = 100 ether;
+
+    _setupBuyThenSell(marketIds, amount);
+
+    uint256 price0 = (40 * ONE) / 100;
+    uint256 price1 = (30 * ONE) / 100;
+    uint256 price2 = (20 * ONE) / 100;
+
+    MyriadCTFExchange.Order[] memory sellOrders = new MyriadCTFExchange.Order[](3);
+    sellOrders[0] = _buildOrder(alice, marketIds[0], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price0, 700);
+    sellOrders[1] = _buildOrder(bob, marketIds[1], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price1, 701);
+    sellOrders[2] = _buildOrder(charlie, marketIds[2], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price2, 702);
+
+    bytes[] memory sigs = new bytes[](3);
+    sigs[0] = _signOrder(sellOrders[0], alicePk);
+    sigs[1] = _signOrder(sellOrders[1], bobPk);
+    sigs[2] = _signOrder(sellOrders[2], charliePk);
+
+    exchange.mergeCrossMarketOrders(sellOrders, sigs, amount);
+
+    bytes32 hash0 = exchange.hashOrder(sellOrders[0]);
+    assertEq(exchange.filledAmounts(hash0), amount);
+  }
+
+  function testMergeCrossMarketPartialFill() public {
+    (, uint256[] memory marketIds) = _createThreeOutcomeEvent();
+    uint256 amount = 100 ether;
+    uint256 fillAmount = 40 ether;
+
+    _setupBuyThenSell(marketIds, amount);
+
+    uint256 price0 = (45 * ONE) / 100;
+    uint256 price1 = (35 * ONE) / 100;
+    uint256 price2 = (20 * ONE) / 100;
+
+    MyriadCTFExchange.Order[] memory sellOrders = new MyriadCTFExchange.Order[](3);
+    sellOrders[0] = _buildOrder(alice, marketIds[0], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price0, 800);
+    sellOrders[1] = _buildOrder(bob, marketIds[1], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price1, 801);
+    sellOrders[2] = _buildOrder(charlie, marketIds[2], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price2, 802);
+
+    bytes[] memory sigs = new bytes[](3);
+    sigs[0] = _signOrder(sellOrders[0], alicePk);
+    sigs[1] = _signOrder(sellOrders[1], bobPk);
+    sigs[2] = _signOrder(sellOrders[2], charliePk);
+
+    exchange.mergeCrossMarketOrders(sellOrders, sigs, fillAmount);
+
+    assertEq(conditionalTokens.balanceOf(alice, conditionalTokens.getTokenId(marketIds[0], Outcomes.YES)), amount - fillAmount);
+    bytes32 hash0 = exchange.hashOrder(sellOrders[0]);
+    assertEq(exchange.filledAmounts(hash0), fillAmount);
+  }
+
+  function testMergeCrossMarketMakerTakerFees() public {
+    (, uint256[] memory marketIds) = _createThreeOutcomeEvent();
+    uint256 amount = 100 ether;
+
+    _setupBuyThenSell(marketIds, amount);
+
+    // Override fees after setup (which sets 1%/2%) to 1% maker / 3% taker
+    for (uint256 i = 0; i < 3; i++) _setUniformFees(marketIds[i], 100, 300);
+
+    uint256 price0 = (40 * ONE) / 100;
+    uint256 price1 = (30 * ONE) / 100;
+    uint256 price2 = (30 * ONE) / 100;
+
+    MyriadCTFExchange.Order[] memory sellOrders = new MyriadCTFExchange.Order[](3);
+    sellOrders[0] = _buildOrder(alice, marketIds[0], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price0, 1100);
+    sellOrders[1] = _buildOrder(bob, marketIds[1], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price1, 1101);
+    sellOrders[2] = _buildOrder(charlie, marketIds[2], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price2, 1102);
+
+    bytes[] memory sigs = new bytes[](3);
+    sigs[0] = _signOrder(sellOrders[0], alicePk);
+    sigs[1] = _signOrder(sellOrders[1], bobPk);
+    sigs[2] = _signOrder(sellOrders[2], charliePk);
+
+    uint256 aliceBefore = wcol.balanceOf(alice);
+    uint256 bobBefore = wcol.balanceOf(bob);
+    uint256 charlieBefore = wcol.balanceOf(charlie);
+    uint256 feeModuleBefore = wcol.balanceOf(address(feeModule));
+
+    exchange.mergeCrossMarketOrders(sellOrders, sigs, amount);
+
+    uint256 aliceNotional = (amount * price0) / ONE;
+    uint256 aliceFee = (aliceNotional * 100) / BPS;
+    assertEq(wcol.balanceOf(alice) - aliceBefore, aliceNotional - aliceFee, "alice receives notional - makerFee");
+
+    uint256 bobNotional = (amount * price1) / ONE;
+    uint256 bobFee = (bobNotional * 100) / BPS;
+    assertEq(wcol.balanceOf(bob) - bobBefore, bobNotional - bobFee, "bob receives notional - makerFee");
+
+    uint256 charlieNotional = (amount * price2) / ONE;
+    uint256 charlieFee = (charlieNotional * 300) / BPS;
+    assertEq(wcol.balanceOf(charlie) - charlieBefore, charlieNotional - charlieFee, "charlie receives notional - takerFee");
+
+    uint256 totalFees = aliceFee + bobFee + charlieFee;
+    assertEq(wcol.balanceOf(address(feeModule)) - feeModuleBefore, totalFees, "feeModule received exact fees");
+  }
+
+  function testMergeCrossMarketSurplusEmitsEvent() public {
+    (, uint256[] memory marketIds) = _createThreeOutcomeEvent();
+    uint256 amount = 100 ether;
+
+    _setupBuyThenSell(marketIds, amount);
+
+    uint256 price0 = (40 * ONE) / 100;
+    uint256 price1 = (30 * ONE) / 100;
+    uint256 price2 = (20 * ONE) / 100;
+
+    MyriadCTFExchange.Order[] memory sellOrders = new MyriadCTFExchange.Order[](3);
+    sellOrders[0] = _buildOrder(alice, marketIds[0], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price0, 1200);
+    sellOrders[1] = _buildOrder(bob, marketIds[1], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price1, 1201);
+    sellOrders[2] = _buildOrder(charlie, marketIds[2], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price2, 1202);
+
+    bytes[] memory sigs = new bytes[](3);
+    sigs[0] = _signOrder(sellOrders[0], alicePk);
+    sigs[1] = _signOrder(sellOrders[1], bobPk);
+    sigs[2] = _signOrder(sellOrders[2], charliePk);
+
+    bytes32 eventId = manager.getEventId(marketIds[0]);
+    uint256 expectedSurplus = amount - ((amount * price0) / ONE + (amount * price1) / ONE + (amount * price2) / ONE);
+
+    vm.expectEmit(true, false, false, true, address(exchange));
+    emit MyriadCTFExchange.SurplusCollected(eventId, expectedSurplus);
+
+    exchange.mergeCrossMarketOrders(sellOrders, sigs, amount);
+  }
+
+  function testMergeCrossMarketSurplusWithFees() public {
+    (, uint256[] memory marketIds) = _createThreeOutcomeEvent();
+    uint256 amount = 100 ether;
+
+    for (uint256 i = 0; i < 3; i++) _setUniformFees(marketIds[i], 100, 200);
+
+    _setupBuyThenSell(marketIds, amount);
+
+    uint256 price0 = (40 * ONE) / 100;
+    uint256 price1 = (30 * ONE) / 100;
+    uint256 price2 = (20 * ONE) / 100;
+
+    MyriadCTFExchange.Order[] memory sellOrders = new MyriadCTFExchange.Order[](3);
+    sellOrders[0] = _buildOrder(alice, marketIds[0], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price0, 1300);
+    sellOrders[1] = _buildOrder(bob, marketIds[1], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price1, 1301);
+    sellOrders[2] = _buildOrder(charlie, marketIds[2], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price2, 1302);
+
+    bytes[] memory sigs = new bytes[](3);
+    sigs[0] = _signOrder(sellOrders[0], alicePk);
+    sigs[1] = _signOrder(sellOrders[1], bobPk);
+    sigs[2] = _signOrder(sellOrders[2], charliePk);
+
+    uint256 feeModuleBefore = wcol.balanceOf(address(feeModule));
+
+    exchange.mergeCrossMarketOrders(sellOrders, sigs, amount);
+
+    uint256 n0 = (amount * price0) / ONE;
+    uint256 n1 = (amount * price1) / ONE;
+    uint256 n2 = (amount * price2) / ONE;
+    uint256 totalNotional = n0 + n1 + n2;
+    uint256 surplus = amount - totalNotional;
+    uint256 fee0 = (n0 * 100) / BPS;
+    uint256 fee1 = (n1 * 100) / BPS;
+    uint256 fee2 = (n2 * 200) / BPS;
+    uint256 totalFees = fee0 + fee1 + fee2;
+
+    assertEq(wcol.balanceOf(address(feeModule)) - feeModuleBefore, surplus + totalFees, "feeModule gets surplus + fees");
+  }
+
+  function testMergeCrossMarketTokensNotApprovedReverts() public {
+    (, uint256[] memory marketIds) = _createThreeOutcomeEvent();
+    uint256 amount = 100 ether;
+
+    _setupBuyThenSell(marketIds, amount);
+
+    // Charlie revokes ERC-1155 approval for exchange
+    vm.prank(charlie);
+    conditionalTokens.setApprovalForAll(address(exchange), false);
+
+    uint256 price0 = (45 * ONE) / 100;
+    uint256 price1 = (35 * ONE) / 100;
+    uint256 price2 = (20 * ONE) / 100;
+
+    MyriadCTFExchange.Order[] memory sellOrders = new MyriadCTFExchange.Order[](3);
+    sellOrders[0] = _buildOrder(alice, marketIds[0], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price0, 1400);
+    sellOrders[1] = _buildOrder(bob, marketIds[1], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price1, 1401);
+    sellOrders[2] = _buildOrder(charlie, marketIds[2], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price2, 1402);
+
+    bytes[] memory sigs = new bytes[](3);
+    sigs[0] = _signOrder(sellOrders[0], alicePk);
+    sigs[1] = _signOrder(sellOrders[1], bobPk);
+    sigs[2] = _signOrder(sellOrders[2], charliePk);
+
+    vm.expectRevert("tokens not approved");
+    exchange.mergeCrossMarketOrders(sellOrders, sigs, amount);
+  }
+
+  function testMergeCrossMarketBelowMinAmountReverts() public {
+    (, uint256[] memory marketIds) = _createThreeOutcomeEvent();
+    exchange.setMinOrderAmount(10 ether);
+
+    uint256 price0 = (45 * ONE) / 100;
+    uint256 price1 = (35 * ONE) / 100;
+    uint256 price2 = (20 * ONE) / 100;
+
+    MyriadCTFExchange.Order[] memory orders = new MyriadCTFExchange.Order[](3);
+    orders[0] = _buildOrder(alice, marketIds[0], Outcomes.YES, MyriadCTFExchange.Side.Sell, 5 ether, price0, 1500);
+    orders[1] = _buildOrder(bob, marketIds[1], Outcomes.YES, MyriadCTFExchange.Side.Sell, 5 ether, price1, 1501);
+    orders[2] = _buildOrder(charlie, marketIds[2], Outcomes.YES, MyriadCTFExchange.Side.Sell, 5 ether, price2, 1502);
+
+    bytes[] memory sigs = new bytes[](3);
+    sigs[0] = _signOrder(orders[0], alicePk);
+    sigs[1] = _signOrder(orders[1], bobPk);
+    sigs[2] = _signOrder(orders[2], charliePk);
+
+    vm.expectRevert("below min amount");
+    exchange.mergeCrossMarketOrders(orders, sigs, 5 ether);
+  }
+
+  function testMergeCrossMarketDustRemainderReverts() public {
+    (, uint256[] memory marketIds) = _createThreeOutcomeEvent();
+    uint256 amount = 100 ether;
+
+    _setupBuyThenSell(marketIds, amount);
+    exchange.setMinOrderAmount(10 ether);
+
+    uint256 price0 = (45 * ONE) / 100;
+    uint256 price1 = (35 * ONE) / 100;
+    uint256 price2 = (20 * ONE) / 100;
+
+    MyriadCTFExchange.Order[] memory sellOrders = new MyriadCTFExchange.Order[](3);
+    sellOrders[0] = _buildOrder(alice, marketIds[0], Outcomes.YES, MyriadCTFExchange.Side.Sell, 25 ether, price0, 1600);
+    sellOrders[1] = _buildOrder(bob, marketIds[1], Outcomes.YES, MyriadCTFExchange.Side.Sell, 20 ether, price1, 1601);
+    sellOrders[2] = _buildOrder(charlie, marketIds[2], Outcomes.YES, MyriadCTFExchange.Side.Sell, 20 ether, price2, 1602);
+
+    bytes[] memory sigs = new bytes[](3);
+    sigs[0] = _signOrder(sellOrders[0], alicePk);
+    sigs[1] = _signOrder(sellOrders[1], bobPk);
+    sigs[2] = _signOrder(sellOrders[2], charliePk);
+
+    vm.expectRevert("dust remainder");
+    exchange.mergeCrossMarketOrders(sellOrders, sigs, 20 ether);
+  }
+
+  function testMergeCrossMarketExactRemainderAtMinAllowed() public {
+    (, uint256[] memory marketIds) = _createThreeOutcomeEvent();
+    uint256 amount = 100 ether;
+
+    _setupBuyThenSell(marketIds, amount);
+    exchange.setMinOrderAmount(10 ether);
+
+    uint256 price0 = (45 * ONE) / 100;
+    uint256 price1 = (35 * ONE) / 100;
+    uint256 price2 = (20 * ONE) / 100;
+
+    MyriadCTFExchange.Order[] memory sellOrders = new MyriadCTFExchange.Order[](3);
+    sellOrders[0] = _buildOrder(alice, marketIds[0], Outcomes.YES, MyriadCTFExchange.Side.Sell, 30 ether, price0, 1700);
+    sellOrders[1] = _buildOrder(bob, marketIds[1], Outcomes.YES, MyriadCTFExchange.Side.Sell, 20 ether, price1, 1701);
+    sellOrders[2] = _buildOrder(charlie, marketIds[2], Outcomes.YES, MyriadCTFExchange.Side.Sell, 20 ether, price2, 1702);
+
+    bytes[] memory sigs = new bytes[](3);
+    sigs[0] = _signOrder(sellOrders[0], alicePk);
+    sigs[1] = _signOrder(sellOrders[1], bobPk);
+    sigs[2] = _signOrder(sellOrders[2], charliePk);
+
+    exchange.mergeCrossMarketOrders(sellOrders, sigs, 20 ether);
+
+    bytes32 hash0 = exchange.hashOrder(sellOrders[0]);
+    assertEq(exchange.filledAmounts(hash0), 20 ether);
+  }
+
+  function testMergeAllYesTokensOnlyExchangeReverts() public {
+    (bytes32 eventId, ) = _createThreeOutcomeEvent();
+
+    vm.prank(alice);
+    vm.expectRevert("only exchange");
+    adapter.mergeAllYesTokens(eventId, 10 ether);
+  }
+
+  function testMergeCrossMarketRoundTrip() public {
+    (, uint256[] memory marketIds) = _createThreeOutcomeEvent();
+    uint256 amount = 100 ether;
+
+    for (uint256 i = 0; i < 3; i++) _setUniformFees(marketIds[i], 0, 0);
+
+    uint256 fundAmount = 500 ether;
+    for (uint256 i = 0; i < 3; i++) {
+      address user = i == 0 ? alice : (i == 1 ? bob : charlie);
+      collateral.mint(user, fundAmount);
+      vm.startPrank(user);
+      collateral.approve(address(wcol), fundAmount);
+      wcol.wrap(fundAmount);
+      IERC20(address(wcol)).approve(address(exchange), type(uint256).max);
+      conditionalTokens.setApprovalForAll(address(exchange), true);
+      vm.stopPrank();
+    }
+
+    uint256 price0 = (45 * ONE) / 100;
+    uint256 price1 = (35 * ONE) / 100;
+    uint256 price2 = (20 * ONE) / 100;
+
+    uint256 aliceBefore = wcol.balanceOf(alice);
+    uint256 bobBefore = wcol.balanceOf(bob);
+    uint256 charlieBefore = wcol.balanceOf(charlie);
+
+    // BUY mint
+    MyriadCTFExchange.Order[] memory buyOrders = new MyriadCTFExchange.Order[](3);
+    buyOrders[0] = _buildOrder(alice, marketIds[0], Outcomes.YES, MyriadCTFExchange.Side.Buy, amount, price0, 1800);
+    buyOrders[1] = _buildOrder(bob, marketIds[1], Outcomes.YES, MyriadCTFExchange.Side.Buy, amount, price1, 1801);
+    buyOrders[2] = _buildOrder(charlie, marketIds[2], Outcomes.YES, MyriadCTFExchange.Side.Buy, amount, price2, 1802);
+
+    bytes[] memory buySigs = new bytes[](3);
+    buySigs[0] = _signOrder(buyOrders[0], alicePk);
+    buySigs[1] = _signOrder(buyOrders[1], bobPk);
+    buySigs[2] = _signOrder(buyOrders[2], charliePk);
+
+    exchange.matchCrossMarketOrders(buyOrders, buySigs, amount);
+
+    // SELL merge at same prices
+    MyriadCTFExchange.Order[] memory sellOrders = new MyriadCTFExchange.Order[](3);
+    sellOrders[0] = _buildOrder(alice, marketIds[0], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price0, 1900);
+    sellOrders[1] = _buildOrder(bob, marketIds[1], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price1, 1901);
+    sellOrders[2] = _buildOrder(charlie, marketIds[2], Outcomes.YES, MyriadCTFExchange.Side.Sell, amount, price2, 1902);
+
+    bytes[] memory sellSigs = new bytes[](3);
+    sellSigs[0] = _signOrder(sellOrders[0], alicePk);
+    sellSigs[1] = _signOrder(sellOrders[1], bobPk);
+    sellSigs[2] = _signOrder(sellOrders[2], charliePk);
+
+    exchange.mergeCrossMarketOrders(sellOrders, sellSigs, amount);
+
+    // With 0% fees and priceSum == ONE, each trader should get back exactly what they paid
+    assertEq(wcol.balanceOf(alice), aliceBefore, "alice wcol unchanged after round-trip");
+    assertEq(wcol.balanceOf(bob), bobBefore, "bob wcol unchanged after round-trip");
+    assertEq(wcol.balanceOf(charlie), charlieBefore, "charlie wcol unchanged after round-trip");
+
+    // All YES tokens should be gone
+    assertEq(conditionalTokens.balanceOf(alice, conditionalTokens.getTokenId(marketIds[0], Outcomes.YES)), 0);
+    assertEq(conditionalTokens.balanceOf(bob, conditionalTokens.getTokenId(marketIds[1], Outcomes.YES)), 0);
+    assertEq(conditionalTokens.balanceOf(charlie, conditionalTokens.getTokenId(marketIds[2], Outcomes.YES)), 0);
+  }
+
+  // =========================================================================
   // Void event
   // =========================================================================
 


### PR DESCRIPTION
## Cross-market merge for neg risk events

Adds `mergeCrossMarketOrders` to the exchange — the inverse of `matchCrossMarketOrders`. Sellers holding YES tokens across all outcomes of a neg risk event can now be matched to merge their positions back into collateral.

### Exchange (`MyriadCTFExchange.sol`)
- New `mergeCrossMarketOrders`: collects YES tokens from all sellers, merges via NegRiskAdapter, distributes proceeds (notional - fee) to each seller. Surplus from `priceSum <= ONE` is routed to the fee module.
- Extracted `_validateCrossMarketOrders` shared helper, reused by both mint and merge cross-market flows.
- New `_distributeMergeProceeds` helper for per-seller fee deduction and payout.

### Adapter (`NegRiskAdapter.sol`)
- New `mergeAllYesTokens`: reverse of `mintAllYesTokens`. Merges YES tokens for every outcome, burns the adapter-minted wcol surplus, and returns collateral to the exchange.

### Tests
Round-trip (mint then merge), surplus handling, fee integration, approval reverts, dust remainder checks, min amount enforcement.