### PR TITLE
Optimizations and a correctness fix for MyriadCTFExchange

### DIFF
--- a/contracts/MyriadCTFExchange.sol
+++ b/contracts/MyriadCTFExchange.sol
@@ -164,7 +164,6 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
   error SideMismatch();
   error PriceMismatch();
   error SameOutcome();
-  error PriceSumNotOne();
   error MakerFeesExceedProceeds();
   error TakerFeesExceedProceeds();
   error InsufficientCollateral();
@@ -735,7 +734,7 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     _requireMarketOpen(maker.marketId);
 
     (Order calldata outcome0Order, Order calldata outcome1Order) = maker.outcomeId == Outcomes.YES ? (maker, taker) : (taker, maker);
-    if (outcome0Order.price + outcome1Order.price != ONE) revert PriceSumNotOne();
+    if (outcome0Order.price + outcome1Order.price < ONE) revert PriceSumBelowOne();
 
     IERC20 collateral = manager.getMarketCollateral(maker.marketId);
 
@@ -785,7 +784,7 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     _requireMarketOpen(maker.marketId);
 
     (Order calldata outcome0Order, Order calldata outcome1Order) = maker.outcomeId == Outcomes.YES ? (maker, taker) : (taker, maker);
-    if (outcome0Order.price + outcome1Order.price != ONE) revert PriceSumNotOne();
+    if (outcome0Order.price + outcome1Order.price > ONE) revert PriceAboveOne();
 
     ConditionalTokens _ct = conditionalTokens;
     uint256 outcome0TokenId = _ct.getTokenId(maker.marketId, Outcomes.YES);

--- a/contracts/MyriadCTFExchange.sol
+++ b/contracts/MyriadCTFExchange.sol
@@ -201,37 +201,37 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
   }
 
   function _authorizeUpgrade(address) internal view override {
-    if (!registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), msg.sender)) revert NotAdmin();
+    _requireAdmin();
   }
 
   // ─── Emergency controls ───────────────────────────────────────────────
 
   function pause() external {
-    if (!registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), msg.sender)) revert NotAdmin();
+    _requireAdmin();
     _pause();
   }
 
   function unpause() external {
-    if (!registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), msg.sender)) revert NotAdmin();
+    _requireAdmin();
     _unpause();
   }
 
   function setNegRiskAdapter(address _adapter) external {
-    if (!registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), msg.sender)) revert NotAdmin();
+    _requireAdmin();
     address old = negRiskAdapter;
     negRiskAdapter = _adapter;
     emit NegRiskAdapterUpdated(old, _adapter);
   }
 
   function setCallbackGasLimit(uint256 _limit) external {
-    if (!registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), msg.sender)) revert NotAdmin();
+    _requireAdmin();
     if (_limit < 50_000) revert LimitTooLow();
     emit CallbackGasLimitUpdated(callbackGasLimit, _limit);
     callbackGasLimit = _limit;
   }
 
   function setMinOrderAmount(uint256 _amount) external {
-    if (!registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), msg.sender)) revert NotAdmin();
+    _requireAdmin();
     uint256 old = minOrderAmount;
     minOrderAmount = _amount;
     emit MinOrderAmountUpdated(old, _amount);
@@ -240,13 +240,14 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
   // ─── Order management ────────────────────────────────────────────────
 
   function cancelOrders(Order[] calldata orders) external {
-    for (uint256 i = 0; i < orders.length; i++) {
+    for (uint256 i = 0; i < orders.length;) {
       Order calldata order = orders[i];
       if (order.trader != msg.sender) revert NotTrader();
       bytes32 orderHash = hashOrder(order);
       if (orderInvalidated[orderHash]) revert AlreadyCancelled();
       orderInvalidated[orderHash] = true;
       emit OrderCancelled(orderHash, msg.sender);
+      unchecked { ++i; }
     }
   }
 
@@ -262,7 +263,7 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     bytes calldata takerSig,
     uint256 fillAmount
   ) external whenNotPaused nonReentrant {
-    if (!registry.hasRole(registry.OPERATOR_ROLE(), msg.sender)) revert NotOperator();
+    _requireOperator();
     if (maker.marketId != taker.marketId) revert MarketMismatch();
 
     IFeeModule _feeModule = IFeeModule(feeModule);
@@ -299,7 +300,7 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     Order calldata taker,
     bytes calldata takerSig
   ) external whenNotPaused nonReentrant {
-    if (!registry.hasRole(registry.OPERATOR_ROLE(), msg.sender)) revert NotOperator();
+    _requireOperator();
     uint256 n = makers.length;
     if (n == 0) revert NoMakers();
     if (makerSigs.length != n) revert SigCount();
@@ -313,7 +314,7 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     uint256 totalFees;
     uint256 takerFilledBefore = filledAmounts[takerHash];
 
-    for (uint256 i = 0; i < n; i++) {
+    for (uint256 i = 0; i < n;) {
       if (makers[i].marketId != taker.marketId) revert MarketMismatch();
 
       FeeConfig memory feeConfig;
@@ -332,6 +333,7 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
       );
 
       totalFees += makerFee + takerFee;
+      unchecked { ++i; }
     }
 
     uint256 takerFilledAfter = takerFilledBefore + totalTakerFill;
@@ -363,7 +365,7 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     bytes[] calldata signatures,
     uint256 fillAmount
   ) external whenNotPaused nonReentrant {
-    if (!registry.hasRole(registry.OPERATOR_ROLE(), msg.sender)) revert NotOperator();
+    _requireOperator();
 
     address _adapter = negRiskAdapter;
     if (_adapter == address(0)) revert NoAdapter();
@@ -388,7 +390,7 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     bytes32[] memory orderHashes = new bytes32[](orders.length);
     uint256[] memory currentFilled = new uint256[](orders.length);
 
-    for (uint256 i = 0; i < orders.length; i++) {
+    for (uint256 i = 0; i < orders.length;) {
       Order calldata order = orders[i];
       if (order.side != Side.Buy) revert NotBuy();
       if (order.outcomeId != Outcomes.YES) revert NotYes();
@@ -405,11 +407,13 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
       if (currentFilled[i] + fillAmount > order.amount) revert Overfill();
       if (order.minFillAmount != 0 && fillAmount < order.minFillAmount) revert BelowMinFill();
 
-      for (uint256 j = 0; j < i; j++) {
+      for (uint256 j = 0; j < i;) {
         if (order.marketId == orders[j].marketId) revert DuplicateMarket();
+        unchecked { ++j; }
       }
 
       priceSum += order.price;
+      unchecked { ++i; }
     }
 
     if (priceSum < ONE) revert PriceSumBelowOne();
@@ -421,7 +425,7 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     uint256 takerIdx = orders.length - 1;
 
     uint256 totalNotional;
-    for (uint256 i = 0; i < orders.length; i++) {
+    for (uint256 i = 0; i < orders.length;) {
       uint256 notional = (fillAmount * orders[i].price) / ONE;
       if (i == takerIdx && totalNotional + notional < fillAmount) {
         notional = fillAmount - totalNotional;
@@ -442,6 +446,7 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
       uint256 required = notional + fee;
       _checkCollateralBalance(orders[i].trader, collateral, required);
       collateral.safeTransferFrom(orders[i].trader, address(this), required);
+      unchecked { ++i; }
     }
 
     // Mint full fillAmount shares
@@ -449,7 +454,7 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     INegRiskAdapter(_adapter).mintAllYesTokens(eventId, fillAmount, address(this));
 
     // Distribute YES tokens (fillAmount per outcome) to each buyer
-    for (uint256 i = 0; i < orders.length; i++) {
+    for (uint256 i = 0; i < orders.length;) {
       uint256 tokenId = _ct.getTokenId(orders[i].marketId, Outcomes.YES);
       _safeTransferWithGasCap(address(this), orders[i].trader, tokenId, fillAmount);
 
@@ -462,6 +467,7 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
       }
 
       emit CrossMarketOrderFilled(orderHashes[i], eventId, orders[i].marketId, fillAmount, newFill);
+      unchecked { ++i; }
     }
 
     // Send surplus (priceSum > ONE overage) + fees to feeModule
@@ -858,6 +864,14 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
   ) internal view {
     if (conditionalTokens.balanceOf(trader, tokenId) < required) revert InsufficientTokens();
     if (!conditionalTokens.isApprovedForAll(trader, address(this))) revert TokensNotApproved();
+  }
+
+  function _requireAdmin() internal view {
+    if (!registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), msg.sender)) revert NotAdmin();
+  }
+
+  function _requireOperator() internal view {
+    if (!registry.hasRole(registry.OPERATOR_ROLE(), msg.sender)) revert NotOperator();
   }
 
   function _requireMarketOpen(uint256 marketId) internal view {

--- a/contracts/MyriadCTFExchange.sol
+++ b/contracts/MyriadCTFExchange.sol
@@ -143,6 +143,7 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
   error BelowMinFill();
   error DuplicateMarket();
   error PriceSumBelowOne();
+  error PriceSumAboveOne();
   error ZeroNotional();
   error DustRemainder();
   error SelfTrade();
@@ -784,7 +785,7 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     _requireMarketOpen(maker.marketId);
 
     (Order calldata outcome0Order, Order calldata outcome1Order) = maker.outcomeId == Outcomes.YES ? (maker, taker) : (taker, maker);
-    if (outcome0Order.price + outcome1Order.price > ONE) revert PriceAboveOne();
+    if (outcome0Order.price + outcome1Order.price > ONE) revert PriceSumAboveOne();
 
     ConditionalTokens _ct = conditionalTokens;
     uint256 outcome0TokenId = _ct.getTokenId(maker.marketId, Outcomes.YES);

--- a/contracts/MyriadCTFExchange.sol
+++ b/contracts/MyriadCTFExchange.sol
@@ -114,6 +114,65 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
   event NegRiskAdapterUpdated(address indexed oldAdapter, address indexed newAdapter);
   event SurplusCollected(bytes32 indexed eventId, uint256 amount);
 
+  error ZeroManager();
+  error ZeroCT();
+  error ZeroFeeModule();
+  error ZeroRegistry();
+  error NotAdmin();
+  error LimitTooLow();
+  error NotTrader();
+  error AlreadyCancelled();
+  error NotOperator();
+  error MarketMismatch();
+  error NoMakers();
+  error SigCount();
+  error FillCount();
+  error TakerOverfill();
+  error BelowTakerMinFill();
+  error TakerDustRemainder();
+  error NoAdapter();
+  error NeedAtLeastTwoOrders();
+  error ZeroFill();
+  error NotNegRisk();
+  error MustMatchAllOutcomes();
+  error NotBuy();
+  error NotYes();
+  error BadPrice();
+  error EventMismatch();
+  error Overfill();
+  error BelowMinFill();
+  error DuplicateMarket();
+  error PriceSumBelowOne();
+  error ZeroNotional();
+  error DustRemainder();
+  error SelfTrade();
+  error PriceAboveOne();
+  error MakerOverfill();
+  error BelowMakerMinFill();
+  error MakerDustRemainder();
+  error ZeroTrader();
+  error ZeroAmount();
+  error BelowMinAmount();
+  error OrderExpired();
+  error BadOutcome();
+  error OrderInvalidated();
+  error InvalidSignature();
+  error MakerFeeExceeds();
+  error TakerFeeExceeds();
+  error TransferFailed();
+  error OutcomeMismatch();
+  error SideMismatch();
+  error PriceMismatch();
+  error SameOutcome();
+  error PriceSumNotOne();
+  error MakerFeesExceedProceeds();
+  error TakerFeesExceedProceeds();
+  error InsufficientCollateral();
+  error InsufficientAllowance();
+  error InsufficientTokens();
+  error TokensNotApproved();
+  error MarketNotTradeable();
+
   /// @custom:oz-upgrades-unsafe-allow constructor
   constructor() {
     _disableInitializers();
@@ -125,10 +184,10 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     address _feeModule,
     AdminRegistry _registry
   ) public initializer {
-    require(address(_manager) != address(0), "manager 0");
-    require(address(_conditionalTokens) != address(0), "ct 0");
-    require(_feeModule != address(0), "fee module 0");
-    require(address(_registry) != address(0), "registry 0");
+    if (address(_manager) == address(0)) revert ZeroManager();
+    if (address(_conditionalTokens) == address(0)) revert ZeroCT();
+    if (_feeModule == address(0)) revert ZeroFeeModule();
+    if (address(_registry) == address(0)) revert ZeroRegistry();
 
     __Pausable_init();
     __UUPSUpgradeable_init();
@@ -142,37 +201,37 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
   }
 
   function _authorizeUpgrade(address) internal view override {
-    require(registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), msg.sender), "not admin");
+    if (!registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), msg.sender)) revert NotAdmin();
   }
 
   // ─── Emergency controls ───────────────────────────────────────────────
 
   function pause() external {
-    require(registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), msg.sender), "not admin");
+    if (!registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), msg.sender)) revert NotAdmin();
     _pause();
   }
 
   function unpause() external {
-    require(registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), msg.sender), "not admin");
+    if (!registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), msg.sender)) revert NotAdmin();
     _unpause();
   }
 
   function setNegRiskAdapter(address _adapter) external {
-    require(registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), msg.sender), "not admin");
+    if (!registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), msg.sender)) revert NotAdmin();
     address old = negRiskAdapter;
     negRiskAdapter = _adapter;
     emit NegRiskAdapterUpdated(old, _adapter);
   }
 
   function setCallbackGasLimit(uint256 _limit) external {
-    require(registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), msg.sender), "not admin");
-    require(_limit >= 50_000, "limit too low");
+    if (!registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), msg.sender)) revert NotAdmin();
+    if (_limit < 50_000) revert LimitTooLow();
     emit CallbackGasLimitUpdated(callbackGasLimit, _limit);
     callbackGasLimit = _limit;
   }
 
   function setMinOrderAmount(uint256 _amount) external {
-    require(registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), msg.sender), "not admin");
+    if (!registry.hasRole(registry.DEFAULT_ADMIN_ROLE(), msg.sender)) revert NotAdmin();
     uint256 old = minOrderAmount;
     minOrderAmount = _amount;
     emit MinOrderAmountUpdated(old, _amount);
@@ -183,9 +242,9 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
   function cancelOrders(Order[] calldata orders) external {
     for (uint256 i = 0; i < orders.length; i++) {
       Order calldata order = orders[i];
-      require(order.trader == msg.sender, "not trader");
+      if (order.trader != msg.sender) revert NotTrader();
       bytes32 orderHash = hashOrder(order);
-      require(!orderInvalidated[orderHash], "already cancelled");
+      if (orderInvalidated[orderHash]) revert AlreadyCancelled();
       orderInvalidated[orderHash] = true;
       emit OrderCancelled(orderHash, msg.sender);
     }
@@ -203,8 +262,8 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     bytes calldata takerSig,
     uint256 fillAmount
   ) external whenNotPaused nonReentrant {
-    require(registry.hasRole(registry.OPERATOR_ROLE(), msg.sender), "not operator");
-    require(maker.marketId == taker.marketId, "market mismatch");
+    if (!registry.hasRole(registry.OPERATOR_ROLE(), msg.sender)) revert NotOperator();
+    if (maker.marketId != taker.marketId) revert MarketMismatch();
 
     IFeeModule _feeModule = IFeeModule(feeModule);
 
@@ -240,11 +299,11 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     Order calldata taker,
     bytes calldata takerSig
   ) external whenNotPaused nonReentrant {
-    require(registry.hasRole(registry.OPERATOR_ROLE(), msg.sender), "not operator");
+    if (!registry.hasRole(registry.OPERATOR_ROLE(), msg.sender)) revert NotOperator();
     uint256 n = makers.length;
-    require(n > 0, "no makers");
-    require(makerSigs.length == n, "sig count");
-    require(fillAmounts.length == n, "fill count");
+    if (n == 0) revert NoMakers();
+    if (makerSigs.length != n) revert SigCount();
+    if (fillAmounts.length != n) revert FillCount();
 
     _validateOrder(taker, takerSig);
     bytes32 takerHash = hashOrder(taker);
@@ -255,7 +314,7 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     uint256 takerFilledBefore = filledAmounts[takerHash];
 
     for (uint256 i = 0; i < n; i++) {
-      require(makers[i].marketId == taker.marketId, "market mismatch");
+      if (makers[i].marketId != taker.marketId) revert MarketMismatch();
 
       FeeConfig memory feeConfig;
       if (makers[i].side != taker.side) {
@@ -276,13 +335,13 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     }
 
     uint256 takerFilledAfter = takerFilledBefore + totalTakerFill;
-    require(takerFilledAfter <= taker.amount, "taker overfill");
-    require(taker.minFillAmount == 0 || totalTakerFill >= taker.minFillAmount, "below taker min fill");
+    if (takerFilledAfter > taker.amount) revert TakerOverfill();
+    if (taker.minFillAmount != 0 && totalTakerFill < taker.minFillAmount) revert BelowTakerMinFill();
     filledAmounts[takerHash] = takerFilledAfter;
 
     if (minOrderAmount > 0) {
       uint256 takerRemaining = taker.amount - takerFilledAfter;
-      require(takerRemaining == 0 || takerRemaining >= minOrderAmount, "taker dust remainder");
+      if (takerRemaining != 0 && takerRemaining < minOrderAmount) revert TakerDustRemainder();
     }
 
     if (totalFees > 0) {
@@ -304,13 +363,13 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     bytes[] calldata signatures,
     uint256 fillAmount
   ) external whenNotPaused nonReentrant {
-    require(registry.hasRole(registry.OPERATOR_ROLE(), msg.sender), "not operator");
+    if (!registry.hasRole(registry.OPERATOR_ROLE(), msg.sender)) revert NotOperator();
 
     address _adapter = negRiskAdapter;
-    require(_adapter != address(0), "no adapter");
-    require(orders.length >= 2, "need >= 2 orders");
-    require(signatures.length == orders.length, "sig count");
-    require(fillAmount > 0, "fill 0");
+    if (_adapter == address(0)) revert NoAdapter();
+    if (orders.length < 2) revert NeedAtLeastTwoOrders();
+    if (signatures.length != orders.length) revert SigCount();
+    if (fillAmount == 0) revert ZeroFill();
 
     IMyriadMarketManager _manager = manager;
     ConditionalTokens _ct = conditionalTokens;
@@ -318,11 +377,11 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
 
     // Derive eventId from the first order, then verify ALL orders belong to it.
     bytes32 eventId = _manager.getEventId(orders[0].marketId);
-    require(eventId != bytes32(0), "not neg risk");
+    if (eventId == bytes32(0)) revert NotNegRisk();
 
     {
       uint256 expectedCount = INegRiskAdapter(_adapter).getEventOutcomeCount(eventId);
-      require(orders.length == expectedCount, "must match all outcomes");
+      if (orders.length != expectedCount) revert MustMatchAllOutcomes();
     }
 
     uint256 priceSum;
@@ -331,11 +390,11 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
 
     for (uint256 i = 0; i < orders.length; i++) {
       Order calldata order = orders[i];
-      require(order.side == Side.Buy, "not buy");
-      require(order.outcomeId == Outcomes.YES, "not YES");
-      require(order.price > 0 && order.price <= ONE, "bad price");
-      require(_manager.getEventId(order.marketId) == eventId, "event mismatch");
-      require(_manager.isNegRisk(order.marketId), "not neg risk");
+      if (order.side != Side.Buy) revert NotBuy();
+      if (order.outcomeId != Outcomes.YES) revert NotYes();
+      if (order.price == 0 || order.price > ONE) revert BadPrice();
+      if (_manager.getEventId(order.marketId) != eventId) revert EventMismatch();
+      if (!_manager.isNegRisk(order.marketId)) revert NotNegRisk();
 
       _requireMarketOpen(order.marketId);
       _validateOrder(order, signatures[i]);
@@ -343,17 +402,17 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
       bytes32 h = hashOrder(order);
       orderHashes[i] = h;
       currentFilled[i] = filledAmounts[h];
-      require(currentFilled[i] + fillAmount <= order.amount, "overfill");
-      require(order.minFillAmount == 0 || fillAmount >= order.minFillAmount, "below min fill");
+      if (currentFilled[i] + fillAmount > order.amount) revert Overfill();
+      if (order.minFillAmount != 0 && fillAmount < order.minFillAmount) revert BelowMinFill();
 
       for (uint256 j = 0; j < i; j++) {
-        require(order.marketId != orders[j].marketId, "dup market");
+        if (order.marketId == orders[j].marketId) revert DuplicateMarket();
       }
 
       priceSum += order.price;
     }
 
-    require(priceSum >= ONE, "price sum < 1");
+    if (priceSum < ONE) revert PriceSumBelowOne();
 
     // Collect wcol from each buyer: notional + fee.
     // Convention: last order = taker, all others = makers.
@@ -367,7 +426,7 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
       if (i == takerIdx && totalNotional + notional < fillAmount) {
         notional = fillAmount - totalNotional;
       }
-      require(notional > 0, "notional 0");
+      if (notional == 0) revert ZeroNotional();
       totalNotional += notional;
 
       uint256 fee;
@@ -399,7 +458,7 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
 
       if (minOrderAmount > 0) {
         uint256 remaining = orders[i].amount - newFill;
-        require(remaining == 0 || remaining >= minOrderAmount, "dust remainder");
+        if (remaining != 0 && remaining < minOrderAmount) revert DustRemainder();
       }
 
       emit CrossMarketOrderFilled(orderHashes[i], eventId, orders[i].marketId, fillAmount, newFill);
@@ -461,15 +520,15 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
 
     bytes32 takerHash = hashOrder(taker);
     uint256 takerFilled = filledAmounts[takerHash];
-    require(takerFilled + fillAmount <= taker.amount, "taker overfill");
-    require(taker.minFillAmount == 0 || fillAmount >= taker.minFillAmount, "below taker min fill");
+    if (takerFilled + fillAmount > taker.amount) revert TakerOverfill();
+    if (taker.minFillAmount != 0 && fillAmount < taker.minFillAmount) revert BelowTakerMinFill();
 
     takerFilled += fillAmount;
     filledAmounts[takerHash] = takerFilled;
 
     if (minOrderAmount > 0) {
       uint256 takerRemaining = taker.amount - takerFilled;
-      require(takerRemaining == 0 || takerRemaining >= minOrderAmount, "taker dust remainder");
+      if (takerRemaining != 0 && takerRemaining < minOrderAmount) revert TakerDustRemainder();
     }
 
     (makerFee, takerFee) = _matchOrdersSingleValidation(
@@ -493,16 +552,16 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     _validateFeeConfig(feeConfig);
     _validateOrder(maker, makerSig);
 
-    require(maker.trader != taker.trader, "self trade");
-    require(maker.price > 0 && taker.price > 0, "bad price");
-    require(maker.price <= ONE && taker.price <= ONE, "price > 1");
-    require(fillAmount > 0, "fill 0");
+    if (maker.trader == taker.trader) revert SelfTrade();
+    if (maker.price == 0 || taker.price == 0) revert BadPrice();
+    if (maker.price > ONE || taker.price > ONE) revert PriceAboveOne();
+    if (fillAmount == 0) revert ZeroFill();
 
     bytes32 makerHash = hashOrder(maker);
 
     uint256 makerFilled = filledAmounts[makerHash];
-    require(makerFilled + fillAmount <= maker.amount, "maker overfill");
-    require(maker.minFillAmount == 0 || fillAmount >= maker.minFillAmount, "below maker min fill");
+    if (makerFilled + fillAmount > maker.amount) revert MakerOverfill();
+    if (maker.minFillAmount != 0 && fillAmount < maker.minFillAmount) revert BelowMakerMinFill();
 
     uint8 matchType;
     if (maker.side != taker.side) {
@@ -534,7 +593,7 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
 
     if (minOrderAmount > 0) {
       uint256 makerRemaining = maker.amount - makerFilled;
-      require(makerRemaining == 0 || makerRemaining >= minOrderAmount, "maker dust remainder");
+      if (makerRemaining != 0 && makerRemaining < minOrderAmount) revert MakerDustRemainder();
     }
 
     if (matchType == 0) {
@@ -561,24 +620,21 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
   }
 
   function _validateOrder(Order calldata order, bytes calldata signature) internal view {
-    require(order.trader != address(0), "trader 0");
-    require(order.amount > 0, "amount 0");
-    require(minOrderAmount == 0 || order.amount >= minOrderAmount, "below min amount");
-    require(order.expiration == 0 || order.expiration > block.timestamp, "expired");
-    require(order.outcomeId < 2, "bad outcome");
+    if (order.trader == address(0)) revert ZeroTrader();
+    if (order.amount == 0) revert ZeroAmount();
+    if (minOrderAmount != 0 && order.amount < minOrderAmount) revert BelowMinAmount();
+    if (order.expiration != 0 && order.expiration <= block.timestamp) revert OrderExpired();
+    if (order.outcomeId >= 2) revert BadOutcome();
 
     bytes32 orderHash = hashOrder(order);
-    require(!orderInvalidated[orderHash], "invalidated");
+    if (orderInvalidated[orderHash]) revert OrderInvalidated();
 
-    require(
-      SignatureChecker.isValidSignatureNow(order.trader, orderHash, signature),
-      "invalid signature"
-    );
+    if (!SignatureChecker.isValidSignatureNow(order.trader, orderHash, signature)) revert InvalidSignature();
   }
 
   function _validateFeeConfig(FeeConfig memory feeConfig) internal pure {
-    require(feeConfig.makerFeeBps <= BPS, "maker fee");
-    require(feeConfig.takerFeeBps <= BPS, "taker fee");
+    if (feeConfig.makerFeeBps > BPS) revert MakerFeeExceeds();
+    if (feeConfig.takerFeeBps > BPS) revert TakerFeeExceeds();
   }
 
   /// @dev Gas-capped ERC-1155 transfer to an arbitrary trader.
@@ -597,7 +653,7 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
       if (returndata.length > 0) {
         assembly ("memory-safe") { revert(add(returndata, 32), mload(returndata)) }
       }
-      revert("transfer failed");
+      revert TransferFailed();
     }
   }
 
@@ -610,20 +666,20 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     uint256 fillAmount,
     FeeConfig memory feeConfig
   ) internal returns (uint256 makerFee, uint256 takerFee) {
-    require(maker.outcomeId == taker.outcomeId, "outcome mismatch");
+    if (maker.outcomeId != taker.outcomeId) revert OutcomeMismatch();
 
     if (maker.side == Side.Buy) {
-      require(taker.side == Side.Sell, "side mismatch");
-      require(maker.price >= taker.price, "price mismatch");
+      if (taker.side != Side.Sell) revert SideMismatch();
+      if (maker.price < taker.price) revert PriceMismatch();
     } else {
-      require(taker.side == Side.Buy, "side mismatch");
-      require(maker.price <= taker.price, "price mismatch");
+      if (taker.side != Side.Buy) revert SideMismatch();
+      if (maker.price > taker.price) revert PriceMismatch();
     }
 
     _requireMarketOpen(maker.marketId);
 
     uint256 notional = (fillAmount * maker.price) / ONE;
-    require(notional > 0, "notional 0");
+    if (notional == 0) revert ZeroNotional();
 
     IERC20 collateral = manager.getMarketCollateral(maker.marketId);
 
@@ -668,18 +724,18 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     uint256 fillAmount,
     FeeConfig memory feeConfig
   ) internal returns (uint256 makerFee, uint256 takerFee) {
-    require(maker.side == Side.Buy && taker.side == Side.Buy, "side mismatch");
-    require(maker.outcomeId != taker.outcomeId, "same outcome");
+    if (maker.side != Side.Buy || taker.side != Side.Buy) revert SideMismatch();
+    if (maker.outcomeId == taker.outcomeId) revert SameOutcome();
     _requireMarketOpen(maker.marketId);
 
     (Order calldata outcome0Order, Order calldata outcome1Order) = maker.outcomeId == Outcomes.YES ? (maker, taker) : (taker, maker);
-    require(outcome0Order.price + outcome1Order.price == ONE, "price sum");
+    if (outcome0Order.price + outcome1Order.price != ONE) revert PriceSumNotOne();
 
     IERC20 collateral = manager.getMarketCollateral(maker.marketId);
 
     uint256 makerNotional = (fillAmount * maker.price) / ONE;
     uint256 takerNotional = fillAmount - makerNotional;
-    require(makerNotional > 0 && takerNotional > 0, "notional 0");
+    if (makerNotional == 0 || takerNotional == 0) revert ZeroNotional();
 
     makerFee = (makerNotional * feeConfig.makerFeeBps) / BPS;
     takerFee = (takerNotional * feeConfig.takerFeeBps) / BPS;
@@ -718,12 +774,12 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     uint256 fillAmount,
     FeeConfig memory feeConfig
   ) internal returns (uint256 makerFee, uint256 takerFee) {
-    require(maker.side == Side.Sell && taker.side == Side.Sell, "side mismatch");
-    require(maker.outcomeId != taker.outcomeId, "same outcome");
+    if (maker.side != Side.Sell || taker.side != Side.Sell) revert SideMismatch();
+    if (maker.outcomeId == taker.outcomeId) revert SameOutcome();
     _requireMarketOpen(maker.marketId);
 
     (Order calldata outcome0Order, Order calldata outcome1Order) = maker.outcomeId == Outcomes.YES ? (maker, taker) : (taker, maker);
-    require(outcome0Order.price + outcome1Order.price == ONE, "price sum");
+    if (outcome0Order.price + outcome1Order.price != ONE) revert PriceSumNotOne();
 
     ConditionalTokens _ct = conditionalTokens;
     uint256 outcome0TokenId = _ct.getTokenId(maker.marketId, Outcomes.YES);
@@ -740,7 +796,7 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
 
     uint256 outcome0Notional = (fillAmount * outcome0Order.price) / ONE;
     uint256 outcome1Notional = fillAmount - outcome0Notional;
-    require(outcome0Notional > 0 && outcome1Notional > 0, "notional 0");
+    if (outcome0Notional == 0 || outcome1Notional == 0) revert ZeroNotional();
 
     (makerFee, takerFee) = _paySellerWithFees(maker, taker, fillAmount, feeConfig, collateral, outcome0Order, outcome1Order, outcome0Notional, outcome1Notional);
   }
@@ -770,10 +826,10 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     uint256 makerProceeds = makerTrader == outcome0Order.trader ? outcome0Notional : outcome1Notional;
     uint256 takerProceeds = takerTrader == outcome0Order.trader ? outcome0Notional : outcome1Notional;
 
-    require(makerProceeds >= makerFee, "maker fees exceed proceeds");
+    if (makerProceeds < makerFee) revert MakerFeesExceedProceeds();
     makerProceeds -= makerFee;
 
-    require(takerProceeds >= takerFee, "taker fees exceed proceeds");
+    if (takerProceeds < takerFee) revert TakerFeesExceedProceeds();
     takerProceeds -= takerFee;
 
     collateral.safeTransfer(outcome0Order.trader, makerTrader == outcome0Order.trader ? makerProceeds : takerProceeds);
@@ -791,8 +847,8 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     IERC20 collateral,
     uint256 required
   ) internal view {
-    require(collateral.balanceOf(trader) >= required, "insufficient collateral");
-    require(collateral.allowance(trader, address(this)) >= required, "insufficient allowance");
+    if (collateral.balanceOf(trader) < required) revert InsufficientCollateral();
+    if (collateral.allowance(trader, address(this)) < required) revert InsufficientAllowance();
   }
 
   function _checkTokenBalance(
@@ -800,11 +856,11 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     uint256 tokenId,
     uint256 required
   ) internal view {
-    require(conditionalTokens.balanceOf(trader, tokenId) >= required, "insufficient tokens");
-    require(conditionalTokens.isApprovedForAll(trader, address(this)), "tokens not approved");
+    if (conditionalTokens.balanceOf(trader, tokenId) < required) revert InsufficientTokens();
+    if (!conditionalTokens.isApprovedForAll(trader, address(this))) revert TokensNotApproved();
   }
 
   function _requireMarketOpen(uint256 marketId) internal view {
-    require(manager.isMarketTradeable(marketId), "market not tradeable");
+    if (!manager.isMarketTradeable(marketId)) revert MarketNotTradeable();
   }
 }

--- a/contracts/MyriadCTFExchange.sol
+++ b/contracts/MyriadCTFExchange.sol
@@ -820,19 +820,17 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     uint256 outcome0Notional,
     uint256 outcome1Notional
   ) internal returns (uint256 makerFee, uint256 takerFee) {
-    address makerTrader = maker.trader;
+    bool makerIsOutcome0 = maker.outcomeId == Outcomes.YES;
 
-    uint256 makerNotional = makerTrader == outcome0Order.trader ? outcome0Notional : outcome1Notional;
-    uint256 takerNotional = makerTrader == outcome0Order.trader ? outcome1Notional : outcome0Notional;
+    uint256 makerNotional = makerIsOutcome0 ? outcome0Notional : outcome1Notional;
+    uint256 takerNotional = makerIsOutcome0 ? outcome1Notional : outcome0Notional;
 
     makerFee = (makerNotional * feeConfig.makerFeeBps) / BPS;
     takerFee = (takerNotional * feeConfig.takerFeeBps) / BPS;
     uint256 totalProtocolFees = makerFee + takerFee;
 
-    address takerTrader = taker.trader;
-
-    uint256 makerProceeds = makerTrader == outcome0Order.trader ? outcome0Notional : outcome1Notional;
-    uint256 takerProceeds = takerTrader == outcome0Order.trader ? outcome0Notional : outcome1Notional;
+    uint256 makerProceeds = makerNotional;
+    uint256 takerProceeds = takerNotional;
 
     if (makerProceeds < makerFee) revert MakerFeesExceedProceeds();
     makerProceeds -= makerFee;
@@ -840,8 +838,8 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     if (takerProceeds < takerFee) revert TakerFeesExceedProceeds();
     takerProceeds -= takerFee;
 
-    collateral.safeTransfer(outcome0Order.trader, makerTrader == outcome0Order.trader ? makerProceeds : takerProceeds);
-    collateral.safeTransfer(outcome1Order.trader, makerTrader == outcome1Order.trader ? makerProceeds : takerProceeds);
+    collateral.safeTransfer(outcome0Order.trader, makerIsOutcome0 ? makerProceeds : takerProceeds);
+    collateral.safeTransfer(outcome1Order.trader, makerIsOutcome0 ? takerProceeds : makerProceeds);
 
     if (totalProtocolFees > 0) {
       collateral.safeTransfer(feeModule, totalProtocolFees);

--- a/contracts/MyriadCTFExchange.sol
+++ b/contracts/MyriadCTFExchange.sol
@@ -273,7 +273,7 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
         _feeModule.getFeesAtPrice(maker.marketId, maker.price);
     } else {
       (feeConfig.makerFeeBps, ) = _feeModule.getFeesAtPrice(maker.marketId, maker.price);
-      (, feeConfig.takerFeeBps) = _feeModule.getFeesAtPrice(maker.marketId, taker.price);
+      (, feeConfig.takerFeeBps) = _feeModule.getFeesAtPrice(maker.marketId, ONE - maker.price);
     }
 
     (uint256 makerFee, uint256 takerFee) = _matchOrders(maker, makerSig, taker, takerSig, fillAmount, feeConfig);
@@ -322,7 +322,7 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
           _feeModule.getFeesAtPrice(makers[i].marketId, makers[i].price);
       } else {
         (feeConfig.makerFeeBps, ) = _feeModule.getFeesAtPrice(makers[i].marketId, makers[i].price);
-        (, feeConfig.takerFeeBps) = _feeModule.getFeesAtPrice(makers[i].marketId, taker.price);
+        (, feeConfig.takerFeeBps) = _feeModule.getFeesAtPrice(makers[i].marketId, ONE - makers[i].price);
       }
 
       totalTakerFill += fillAmounts[i];

--- a/contracts/MyriadCTFExchange.sol
+++ b/contracts/MyriadCTFExchange.sol
@@ -806,14 +806,20 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     uint256 outcome1Notional = maker.outcomeId == Outcomes.YES ? takerNotional : makerNotional;
     if (outcome0Notional == 0 || outcome1Notional == 0) revert ZeroNotional();
 
-    (makerFee, takerFee) = _paySellerWithFees(maker, taker, fillAmount, feeConfig, collateral, outcome0Order, outcome1Order, outcome0Notional, outcome1Notional);
+    (makerFee, takerFee) = _paySellerWithFees(
+      maker,
+      feeConfig,
+      collateral,
+      outcome0Order,
+      outcome1Order,
+      outcome0Notional,
+      outcome1Notional
+    );
   }
 
   /// @dev Fee deduction for merge matches — each seller's fee is deducted from their proceeds.
   function _paySellerWithFees(
     Order calldata maker,
-    Order calldata taker,
-    uint256 fillAmount,
     FeeConfig memory feeConfig,
     IERC20 collateral,
     Order calldata outcome0Order,

--- a/contracts/MyriadCTFExchange.sol
+++ b/contracts/MyriadCTFExchange.sol
@@ -799,8 +799,10 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
 
     IERC20 collateral = manager.getMarketCollateral(maker.marketId);
 
-    uint256 outcome0Notional = (fillAmount * outcome0Order.price) / ONE;
-    uint256 outcome1Notional = fillAmount - outcome0Notional;
+    uint256 makerNotional = (fillAmount * maker.price) / ONE;
+    uint256 takerNotional = fillAmount - makerNotional;
+    uint256 outcome0Notional = maker.outcomeId == Outcomes.YES ? makerNotional : takerNotional;
+    uint256 outcome1Notional = maker.outcomeId == Outcomes.YES ? takerNotional : makerNotional;
     if (outcome0Notional == 0 || outcome1Notional == 0) revert ZeroNotional();
 
     (makerFee, takerFee) = _paySellerWithFees(maker, taker, fillAmount, feeConfig, collateral, outcome0Order, outcome1Order, outcome0Notional, outcome1Notional);

--- a/contracts/MyriadCTFExchange.sol
+++ b/contracts/MyriadCTFExchange.sol
@@ -818,14 +818,15 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     uint256 outcome0Notional,
     uint256 outcome1Notional
   ) internal returns (uint256 makerFee, uint256 takerFee) {
-    uint256 makerNotional = (fillAmount * maker.price) / ONE;
-    uint256 takerNotional = fillAmount - makerNotional;
+    address makerTrader = maker.trader;
+
+    uint256 makerNotional = makerTrader == outcome0Order.trader ? outcome0Notional : outcome1Notional;
+    uint256 takerNotional = makerTrader == outcome0Order.trader ? outcome1Notional : outcome0Notional;
 
     makerFee = (makerNotional * feeConfig.makerFeeBps) / BPS;
     takerFee = (takerNotional * feeConfig.takerFeeBps) / BPS;
     uint256 totalProtocolFees = makerFee + takerFee;
 
-    address makerTrader = maker.trader;
     address takerTrader = taker.trader;
 
     uint256 makerProceeds = makerTrader == outcome0Order.trader ? outcome0Notional : outcome1Notional;

--- a/test/MyriadCTFExchange.t.sol
+++ b/test/MyriadCTFExchange.t.sol
@@ -679,7 +679,7 @@ contract MyriadCTFExchangeTest is Test {
     bytes memory mSig = _signOrder(m, makerPk);
     bytes memory tSig = _signOrder(t, takerPk);
 
-    vm.expectRevert(MyriadCTFExchange.PriceAboveOne.selector);
+    vm.expectRevert(MyriadCTFExchange.PriceSumAboveOne.selector);
     exchange.matchOrdersWithFees(m, mSig, t, tSig, amount);
   }
 

--- a/test/MyriadCTFExchange.t.sol
+++ b/test/MyriadCTFExchange.t.sol
@@ -637,7 +637,7 @@ contract MyriadCTFExchangeTest is Test {
     exchange.matchOrdersWithFees(buyOrder, buySig, sellOrder, sellSig, amount);
   }
 
-  function testMintMatchPriceSumNotOneReverts() public {
+  function testMintMatchPriceSumBelowOneReverts() public {
     uint256 amount = 100 ether;
     // prices sum to 0.9 instead of 1.0
     uint256 outcome0Price = (50 * ONE) / 100;
@@ -654,14 +654,14 @@ contract MyriadCTFExchangeTest is Test {
     bytes memory mSig = _signOrder(m, makerPk);
     bytes memory tSig = _signOrder(t, takerPk);
 
-    vm.expectRevert(MyriadCTFExchange.PriceSumNotOne.selector);
+    vm.expectRevert(MyriadCTFExchange.PriceSumBelowOne.selector);
     exchange.matchOrdersWithFees(m, mSig, t, tSig, amount);
   }
 
-  function testMergeMatchPriceSumNotOneReverts() public {
+  function testMergeMatchPriceSumAboveOneReverts() public {
     uint256 amount = 100 ether;
     uint256 outcome0Price = (50 * ONE) / 100;
-    uint256 outcome1Price = (40 * ONE) / 100; // sum = 0.9, not 1.0
+    uint256 outcome1Price = (60 * ONE) / 100; // sum = 1.1, not 1.0
 
     collateral.mint(maker, 1000 ether);
     collateral.mint(taker, 1000 ether);
@@ -679,7 +679,7 @@ contract MyriadCTFExchangeTest is Test {
     bytes memory mSig = _signOrder(m, makerPk);
     bytes memory tSig = _signOrder(t, takerPk);
 
-    vm.expectRevert(MyriadCTFExchange.PriceSumNotOne.selector);
+    vm.expectRevert(MyriadCTFExchange.PriceAboveOne.selector);
     exchange.matchOrdersWithFees(m, mSig, t, tSig, amount);
   }
 

--- a/test/MyriadCTFExchange.t.sol
+++ b/test/MyriadCTFExchange.t.sol
@@ -210,13 +210,13 @@ contract MyriadCTFExchangeTest is Test {
 
     address nonOperator = address(0xBAD);
     vm.prank(nonOperator);
-    vm.expectRevert("not operator");
+    vm.expectRevert(MyriadCTFExchange.NotOperator.selector);
     exchange.matchOrdersWithFees(m, mSig, t, tSig, 100 ether);
   }
 
   function testSetNegRiskAdapterByNonAdminReverts() public {
     vm.prank(address(0xBAD));
-    vm.expectRevert("not admin");
+    vm.expectRevert(MyriadCTFExchange.NotAdmin.selector);
     exchange.setNegRiskAdapter(address(0x1234));
   }
 
@@ -236,7 +236,7 @@ contract MyriadCTFExchangeTest is Test {
 
   function testInitializeWithZeroManagerReverts() public {
     MyriadCTFExchange impl = new MyriadCTFExchange();
-    vm.expectRevert("manager 0");
+    vm.expectRevert(MyriadCTFExchange.ZeroManager.selector);
     new ERC1967Proxy(
       address(impl),
       abi.encodeCall(MyriadCTFExchange.initialize, (
@@ -250,8 +250,7 @@ contract MyriadCTFExchangeTest is Test {
 
   function testInitializeWithZeroConditionalTokensReverts() public {
     MyriadCTFExchange impl = new MyriadCTFExchange();
-    // "ct 0" is 4 bytes — use full Error(string) encoding to avoid bytes4 ambiguity
-    vm.expectRevert(abi.encodeWithSelector(bytes4(0x08c379a0), "ct 0"));
+    vm.expectRevert(MyriadCTFExchange.ZeroCT.selector);
     new ERC1967Proxy(
       address(impl),
       abi.encodeCall(MyriadCTFExchange.initialize, (
@@ -265,7 +264,7 @@ contract MyriadCTFExchangeTest is Test {
 
   function testInitializeWithZeroFeeModuleReverts() public {
     MyriadCTFExchange impl = new MyriadCTFExchange();
-    vm.expectRevert("fee module 0");
+    vm.expectRevert(MyriadCTFExchange.ZeroFeeModule.selector);
     new ERC1967Proxy(
       address(impl),
       abi.encodeCall(MyriadCTFExchange.initialize, (
@@ -279,7 +278,7 @@ contract MyriadCTFExchangeTest is Test {
 
   function testInitializeWithZeroRegistryReverts() public {
     MyriadCTFExchange impl = new MyriadCTFExchange();
-    vm.expectRevert("registry 0");
+    vm.expectRevert(MyriadCTFExchange.ZeroRegistry.selector);
     new ERC1967Proxy(
       address(impl),
       abi.encodeCall(MyriadCTFExchange.initialize, (
@@ -385,7 +384,7 @@ contract MyriadCTFExchangeTest is Test {
     bytes memory badSig  = _signOrder(m, thirdPk);
     bytes memory takerSig = _signOrder(t, takerPk);
 
-    vm.expectRevert("invalid signature");
+    vm.expectRevert(MyriadCTFExchange.InvalidSignature.selector);
     exchange.matchOrdersWithFees(m, badSig, t, takerSig, amount);
   }
 
@@ -403,7 +402,7 @@ contract MyriadCTFExchangeTest is Test {
     bytes memory zeroSig  = new bytes(65);
     bytes memory takerSig = _signOrder(t, takerPk);
 
-    vm.expectRevert("invalid signature");
+    vm.expectRevert(MyriadCTFExchange.InvalidSignature.selector);
     exchange.matchOrdersWithFees(m, zeroSig, t, takerSig, amount);
   }
 
@@ -416,7 +415,7 @@ contract MyriadCTFExchangeTest is Test {
     bytes memory makerSig = _signOrder(m, makerPk);
     bytes memory takerSig = _signOrder(t, takerPk);
 
-    vm.expectRevert("trader 0");
+    vm.expectRevert(MyriadCTFExchange.ZeroTrader.selector);
     exchange.matchOrdersWithFees(m, makerSig, t, takerSig, amount);
   }
 
@@ -427,7 +426,7 @@ contract MyriadCTFExchangeTest is Test {
     bytes memory makerSig = _signOrder(m, makerPk);
     bytes memory takerSig = _signOrder(t, takerPk);
 
-    vm.expectRevert("amount 0");
+    vm.expectRevert(MyriadCTFExchange.ZeroAmount.selector);
     exchange.matchOrdersWithFees(m, makerSig, t, takerSig, 100 ether);
   }
 
@@ -449,7 +448,7 @@ contract MyriadCTFExchangeTest is Test {
     bytes memory makerSig = _signOrder(m, makerPk);
     bytes memory takerSig = _signOrder(t, takerPk);
 
-    vm.expectRevert("bad outcome");
+    vm.expectRevert(MyriadCTFExchange.BadOutcome.selector);
     exchange.matchOrdersWithFees(m, makerSig, t, takerSig, 100 ether);
   }
 
@@ -479,7 +478,7 @@ contract MyriadCTFExchangeTest is Test {
 
     // Warp to exactly the expiration timestamp — order should be expired
     vm.warp(expiry);
-    vm.expectRevert("expired");
+    vm.expectRevert(MyriadCTFExchange.OrderExpired.selector);
     exchange.matchOrdersWithFees(m, makerSig, t, takerSig, 100 ether);
   }
 
@@ -542,7 +541,7 @@ contract MyriadCTFExchangeTest is Test {
     bytes memory mSig = _signOrder(m, makerPk);
     bytes memory tSig = _signOrder(t, takerPk);
 
-    vm.expectRevert("market mismatch");
+    vm.expectRevert(MyriadCTFExchange.MarketMismatch.selector);
     exchange.matchOrdersWithFees(m, mSig, t, tSig, amount);
   }
 
@@ -609,7 +608,7 @@ contract MyriadCTFExchangeTest is Test {
     bytes memory buySig  = _signOrder(buyOrder,  makerPk);
     bytes memory sellSig = _signOrder(sellOrder, takerPk);
 
-    vm.expectRevert("price mismatch");
+    vm.expectRevert(MyriadCTFExchange.PriceMismatch.selector);
     exchange.matchOrdersWithFees(buyOrder, buySig, sellOrder, sellSig, amount);
   }
 
@@ -634,7 +633,7 @@ contract MyriadCTFExchangeTest is Test {
     bytes memory buySig  = _signOrder(buyOrder,  makerPk);
     bytes memory sellSig = _signOrder(sellOrder, takerPk);
 
-    vm.expectRevert("outcome mismatch");
+    vm.expectRevert(MyriadCTFExchange.OutcomeMismatch.selector);
     exchange.matchOrdersWithFees(buyOrder, buySig, sellOrder, sellSig, amount);
   }
 
@@ -655,7 +654,7 @@ contract MyriadCTFExchangeTest is Test {
     bytes memory mSig = _signOrder(m, makerPk);
     bytes memory tSig = _signOrder(t, takerPk);
 
-    vm.expectRevert("price sum");
+    vm.expectRevert(MyriadCTFExchange.PriceSumNotOne.selector);
     exchange.matchOrdersWithFees(m, mSig, t, tSig, amount);
   }
 
@@ -680,7 +679,7 @@ contract MyriadCTFExchangeTest is Test {
     bytes memory mSig = _signOrder(m, makerPk);
     bytes memory tSig = _signOrder(t, takerPk);
 
-    vm.expectRevert("price sum");
+    vm.expectRevert(MyriadCTFExchange.PriceSumNotOne.selector);
     exchange.matchOrdersWithFees(m, mSig, t, tSig, amount);
   }
 

--- a/test/NegRiskAdapter.t.sol
+++ b/test/NegRiskAdapter.t.sol
@@ -427,7 +427,7 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
     sigs[1] = _signOrder(orders[1], bobPk);
     sigs[2] = _signOrder(orders[2], charliePk);
 
-    vm.expectRevert("price sum < 1");
+    vm.expectRevert(MyriadCTFExchange.PriceSumBelowOne.selector);
     exchange.matchCrossMarketOrders(orders, sigs, 10 ether);
   }
 
@@ -825,7 +825,7 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
     sigs[1] = _signOrder(orders[1], bobPk);
     sigs[2] = _signOrder(orders[2], charliePk);
 
-    vm.expectRevert("insufficient collateral");
+    vm.expectRevert(MyriadCTFExchange.InsufficientCollateral.selector);
     exchange.matchCrossMarketOrders(orders, sigs, 100 ether);
   }
 
@@ -861,7 +861,7 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
     sigs[1] = _signOrder(orders[1], bobPk);
     sigs[2] = _signOrder(orders[2], charliePk);
 
-    vm.expectRevert("insufficient allowance");
+    vm.expectRevert(MyriadCTFExchange.InsufficientAllowance.selector);
     exchange.matchCrossMarketOrders(orders, sigs, 100 ether);
   }
 
@@ -889,7 +889,7 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
     sigs[1] = _signOrder(orders[1], bobPk);
     sigs[2] = _signOrder(orders[2], charliePk);
 
-    vm.expectRevert("below min amount");
+    vm.expectRevert(MyriadCTFExchange.BelowMinAmount.selector);
     exchange.matchCrossMarketOrders(orders, sigs, 5 ether);
   }
 
@@ -926,7 +926,7 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
     sigs[1] = _signOrder(orders[1], bobPk);
     sigs[2] = _signOrder(orders[2], charliePk);
 
-    vm.expectRevert("dust remainder");
+    vm.expectRevert(MyriadCTFExchange.DustRemainder.selector);
     exchange.matchCrossMarketOrders(orders, sigs, 20 ether);
   }
 

--- a/test/PredictionMarketCLOB.t.sol
+++ b/test/PredictionMarketCLOB.t.sol
@@ -353,7 +353,7 @@ contract PredictionMarketCLOBTest is Test {
 
     exchange.matchOrdersWithFees(makerOrder, makerSig, takerOrder, takerSig, amount);
 
-    vm.expectRevert("taker overfill");
+    vm.expectRevert(MyriadCTFExchange.TakerOverfill.selector);
     exchange.matchOrdersWithFees(makerOrder, makerSig, takerOrder, takerSig, 2 ether);
   }
 
@@ -382,7 +382,7 @@ contract PredictionMarketCLOBTest is Test {
 
     exchange.matchOrdersWithFees(makerOrder, makerSig, takerOrder, takerSig, amount);
 
-    vm.expectRevert("maker overfill");
+    vm.expectRevert(MyriadCTFExchange.MakerOverfill.selector);
     exchange.matchOrdersWithFees(makerOrder, makerSig, takerOrder, takerSig, 2 ether);
   }
 
@@ -447,7 +447,7 @@ contract PredictionMarketCLOBTest is Test {
     vm.prank(maker);
     exchange.cancelOrders(toCancel);
 
-    vm.expectRevert("invalidated");
+    vm.expectRevert(MyriadCTFExchange.OrderInvalidated.selector);
     exchange.matchOrdersWithFees(makerOrder, makerSig, takerOrder, takerSig, amount);
   }
 
@@ -482,7 +482,7 @@ contract PredictionMarketCLOBTest is Test {
     vm.prank(maker);
     exchange.cancelOrders(toCancel);
 
-    vm.expectRevert("invalidated");
+    vm.expectRevert(MyriadCTFExchange.OrderInvalidated.selector);
     exchange.matchOrdersWithFees(makerOrder, makerSig, takerOrder, takerSig, fill1);
   }
 
@@ -495,7 +495,7 @@ contract PredictionMarketCLOBTest is Test {
     vm.startPrank(maker);
     exchange.cancelOrders(toCancel);
 
-    vm.expectRevert("already cancelled");
+    vm.expectRevert(MyriadCTFExchange.AlreadyCancelled.selector);
     exchange.cancelOrders(toCancel);
     vm.stopPrank();
   }
@@ -507,7 +507,7 @@ contract PredictionMarketCLOBTest is Test {
     toCancel[0] = order;
 
     vm.prank(taker);
-    vm.expectRevert("not trader");
+    vm.expectRevert(MyriadCTFExchange.NotTrader.selector);
     exchange.cancelOrders(toCancel);
   }
 
@@ -533,7 +533,7 @@ contract PredictionMarketCLOBTest is Test {
     bytes memory sig1 = _signOrder(order1, makerPk);
     bytes memory sig2 = _signOrder(order2, makerPk);
 
-    vm.expectRevert("self trade");
+    vm.expectRevert(MyriadCTFExchange.SelfTrade.selector);
     exchange.matchOrdersWithFees(order1, sig1, order2, sig2, amount);
   }
 
@@ -572,7 +572,7 @@ contract PredictionMarketCLOBTest is Test {
 
     vm.warp(block.timestamp + 2);
 
-    vm.expectRevert("expired");
+    vm.expectRevert(MyriadCTFExchange.OrderExpired.selector);
     exchange.matchOrdersWithFees(makerOrder, makerSig, takerOrder, takerSig, amount);
   }
 
@@ -603,7 +603,7 @@ contract PredictionMarketCLOBTest is Test {
     bytes memory makerSig = _signOrder(makerOrder, makerPk);
     bytes memory takerSig = _signOrder(takerOrder, takerPk);
 
-    vm.expectRevert("notional 0");
+    vm.expectRevert(MyriadCTFExchange.ZeroNotional.selector);
     exchange.matchOrdersWithFees(makerOrder, makerSig, takerOrder, takerSig, 1);
   }
 
@@ -708,7 +708,7 @@ contract PredictionMarketCLOBTest is Test {
     bytes memory makerSig = _signOrder(makerOrder, makerPk);
     bytes memory takerSig = _signOrder(takerOrder, takerPk);
 
-    vm.expectRevert("market not tradeable");
+    vm.expectRevert(MyriadCTFExchange.MarketNotTradeable.selector);
     exchange.matchOrdersWithFees(makerOrder, makerSig, takerOrder, takerSig, amount);
   }
 
@@ -737,7 +737,7 @@ contract PredictionMarketCLOBTest is Test {
     bytes memory makerSig = _signOrder(makerOrder, makerPk);
     bytes memory takerSig = _signOrder(takerOrder, takerPk);
 
-    vm.expectRevert("market not tradeable");
+    vm.expectRevert(MyriadCTFExchange.MarketNotTradeable.selector);
     exchange.matchOrdersWithFees(makerOrder, makerSig, takerOrder, takerSig, amount);
   }
 
@@ -986,7 +986,7 @@ contract PredictionMarketCLOBTest is Test {
     bytes memory makerSig = _signOrder(makerOrder, makerPk);
     bytes memory takerSig = _signOrder(takerOrder, takerPk);
 
-    vm.expectRevert("fill 0");
+    vm.expectRevert(MyriadCTFExchange.ZeroFill.selector);
     exchange.matchOrdersWithFees(makerOrder, makerSig, takerOrder, takerSig, 0);
   }
 
@@ -1044,7 +1044,7 @@ contract PredictionMarketCLOBTest is Test {
     bytes memory makerSig = _signOrder(makerOrder, makerPk);
     bytes memory takerSig = _signOrder(takerOrder, takerPk);
 
-    vm.expectRevert("market not tradeable");
+    vm.expectRevert(MyriadCTFExchange.MarketNotTradeable.selector);
     exchange.matchOrdersWithFees(makerOrder, makerSig, takerOrder, takerSig, amount);
 
     manager.pauseMarket(marketId, false);
@@ -1393,7 +1393,7 @@ contract PredictionMarketCLOBTest is Test {
     bytes memory makerSig = _signOrder(makerOrder, makerPk);
     bytes memory takerSig = _signOrder(takerOrder, takerPk);
 
-    vm.expectRevert("below maker min fill");
+    vm.expectRevert(MyriadCTFExchange.BelowMakerMinFill.selector);
     exchange.matchOrdersWithFees(makerOrder, makerSig, takerOrder, takerSig, 49 ether);
 
     exchange.matchOrdersWithFees(makerOrder, makerSig, takerOrder, takerSig, 50 ether);
@@ -1426,7 +1426,7 @@ contract PredictionMarketCLOBTest is Test {
     bytes memory makerSig = _signOrder(makerOrder, makerPk);
     bytes memory takerSig = _signOrder(takerOrder, takerPk);
 
-    vm.expectRevert("below taker min fill");
+    vm.expectRevert(MyriadCTFExchange.BelowTakerMinFill.selector);
     exchange.matchOrdersWithFees(makerOrder, makerSig, takerOrder, takerSig, 29 ether);
 
     exchange.matchOrdersWithFees(makerOrder, makerSig, takerOrder, takerSig, 30 ether);
@@ -1525,7 +1525,7 @@ contract PredictionMarketCLOBTest is Test {
 
   function testPauseNotAdminReverts() public {
     vm.prank(maker);
-    vm.expectRevert("not admin");
+    vm.expectRevert(MyriadCTFExchange.NotAdmin.selector);
     exchange.pause();
   }
 
@@ -1533,7 +1533,7 @@ contract PredictionMarketCLOBTest is Test {
     exchange.pause();
 
     vm.prank(maker);
-    vm.expectRevert("not admin");
+    vm.expectRevert(MyriadCTFExchange.NotAdmin.selector);
     exchange.unpause();
   }
 
@@ -1570,12 +1570,12 @@ contract PredictionMarketCLOBTest is Test {
 
   function testSetCallbackGasLimitNotAdminReverts() public {
     vm.prank(taker);
-    vm.expectRevert("not admin");
+    vm.expectRevert(MyriadCTFExchange.NotAdmin.selector);
     exchange.setCallbackGasLimit(200_000);
   }
 
   function testSetCallbackGasLimitTooLowReverts() public {
-    vm.expectRevert("limit too low");
+    vm.expectRevert(MyriadCTFExchange.LimitTooLow.selector);
     exchange.setCallbackGasLimit(49_999);
   }
 
@@ -1824,7 +1824,7 @@ contract PredictionMarketCLOBTest is Test {
     fills[1] = 100 ether;
     bytes memory takerSig = _signOrder(t, takerPk);
 
-    vm.expectRevert("taker overfill");
+    vm.expectRevert(MyriadCTFExchange.TakerOverfill.selector);
     exchange.matchMultipleOrdersWithFees(makers, makerSigs, fills, t, takerSig);
   }
 
@@ -1854,7 +1854,7 @@ contract PredictionMarketCLOBTest is Test {
     fills[0] = 60 ether;
     bytes memory takerSig = _signOrder(t, takerPk);
 
-    vm.expectRevert("maker overfill");
+    vm.expectRevert(MyriadCTFExchange.MakerOverfill.selector);
     exchange.matchMultipleOrdersWithFees(makers, makerSigs, fills, t, takerSig);
   }
 
@@ -1867,7 +1867,7 @@ contract PredictionMarketCLOBTest is Test {
     uint256[] memory fills = new uint256[](0);
     bytes memory takerSig = _signOrder(t, takerPk);
 
-    vm.expectRevert("no makers");
+    vm.expectRevert(MyriadCTFExchange.NoMakers.selector);
     exchange.matchMultipleOrdersWithFees(makers, makerSigs, fills, t, takerSig);
   }
 
@@ -1885,7 +1885,7 @@ contract PredictionMarketCLOBTest is Test {
     fills[1] = 50 ether;
     bytes memory takerSig = _signOrder(t, takerPk);
 
-    vm.expectRevert("fill count");
+    vm.expectRevert(MyriadCTFExchange.FillCount.selector);
     exchange.matchMultipleOrdersWithFees(makers, makerSigs, fills, t, takerSig);
   }
 
@@ -1913,7 +1913,7 @@ contract PredictionMarketCLOBTest is Test {
     fills[0] = 100 ether;
     bytes memory takerSig = _signOrder(t, makerPk);
 
-    vm.expectRevert("self trade");
+    vm.expectRevert(MyriadCTFExchange.SelfTrade.selector);
     exchange.matchMultipleOrdersWithFees(makers, makerSigs, fills, t, takerSig);
   }
 
@@ -1940,7 +1940,7 @@ contract PredictionMarketCLOBTest is Test {
     fills[0] = 100 ether;
     bytes memory takerSig = _signOrder(t, takerPk);
 
-    vm.expectRevert("market mismatch");
+    vm.expectRevert(MyriadCTFExchange.MarketMismatch.selector);
     exchange.matchMultipleOrdersWithFees(makers, makerSigs, fills, t, takerSig);
   }
 
@@ -1970,7 +1970,7 @@ contract PredictionMarketCLOBTest is Test {
     fills[0] = 50 ether;
     bytes memory takerSig = _signOrder(t, takerPk);
 
-    vm.expectRevert("below taker min fill");
+    vm.expectRevert(MyriadCTFExchange.BelowTakerMinFill.selector);
     exchange.matchMultipleOrdersWithFees(makers, makerSigs, fills, t, takerSig);
   }
 
@@ -2076,7 +2076,7 @@ contract PredictionMarketCLOBTest is Test {
     bytes memory takerSig = _signOrder(t, takerPk);
 
     vm.prank(taker);
-    vm.expectRevert("not operator");
+    vm.expectRevert(MyriadCTFExchange.NotOperator.selector);
     exchange.matchMultipleOrdersWithFees(makers, makerSigs, fills, t, takerSig);
   }
 
@@ -2159,7 +2159,7 @@ contract PredictionMarketCLOBTest is Test {
     fills[0] = 60 ether;
     bytes memory takerSig = _signOrder(t, takerPk);
 
-    vm.expectRevert("maker dust remainder");
+    vm.expectRevert(MyriadCTFExchange.MakerDustRemainder.selector);
     exchange.matchMultipleOrdersWithFees(makers, makerSigs, fills, t, takerSig);
   }
 
@@ -2200,7 +2200,7 @@ contract PredictionMarketCLOBTest is Test {
     fills[1] = 30 ether;
     bytes memory takerSig = _signOrder(t, takerPk);
 
-    vm.expectRevert("taker dust remainder");
+    vm.expectRevert(MyriadCTFExchange.TakerDustRemainder.selector);
     exchange.matchMultipleOrdersWithFees(makers, makerSigs, fills, t, takerSig);
   }
 
@@ -2275,7 +2275,7 @@ contract PredictionMarketCLOBTest is Test {
     fills[0] = amount;
     bytes memory takerSig = _signOrder(t, takerPk);
 
-    vm.expectRevert("insufficient collateral");
+    vm.expectRevert(MyriadCTFExchange.InsufficientCollateral.selector);
     exchange.matchMultipleOrdersWithFees(makers, makerSigs, fills, t, takerSig);
   }
 
@@ -2299,7 +2299,7 @@ contract PredictionMarketCLOBTest is Test {
     fills[0] = amount;
     bytes memory takerSig = _signOrder(t, takerPk);
 
-    vm.expectRevert("insufficient tokens");
+    vm.expectRevert(MyriadCTFExchange.InsufficientTokens.selector);
     exchange.matchMultipleOrdersWithFees(makers, makerSigs, fills, t, takerSig);
   }
 
@@ -2339,7 +2339,7 @@ contract PredictionMarketCLOBTest is Test {
     bytes32 m1Hash = exchange.hashOrder(m1);
     bytes32 m2Hash = exchange.hashOrder(m2);
 
-    vm.expectRevert("taker overfill");
+    vm.expectRevert(MyriadCTFExchange.TakerOverfill.selector);
     exchange.matchMultipleOrdersWithFees(makers, makerSigs, fills, t, tSig);
 
     assertEq(exchange.filledAmounts(tHash), 0, "taker fill rolled back");
@@ -2380,7 +2380,7 @@ contract PredictionMarketCLOBTest is Test {
     bytes32 m1Hash = exchange.hashOrder(m1);
     bytes32 m2Hash = exchange.hashOrder(m2);
 
-    vm.expectRevert("taker dust remainder");
+    vm.expectRevert(MyriadCTFExchange.TakerDustRemainder.selector);
     exchange.matchMultipleOrdersWithFees(makers, makerSigs, fills, t, tSig);
 
     assertEq(exchange.filledAmounts(tHash), 0, "taker fill rolled back on dust");
@@ -2420,7 +2420,7 @@ contract PredictionMarketCLOBTest is Test {
     bytes32 tHash = exchange.hashOrder(t);
     bytes32 m1Hash = exchange.hashOrder(m1);
 
-    vm.expectRevert("insufficient tokens");
+    vm.expectRevert(MyriadCTFExchange.InsufficientTokens.selector);
     exchange.matchMultipleOrdersWithFees(makers, makerSigs, fills, t, tSig);
 
     assertEq(exchange.filledAmounts(tHash), 0, "taker fill rolled back");
@@ -2462,7 +2462,7 @@ contract PredictionMarketCLOBTest is Test {
     uint256[] memory fills = new uint256[](1);
     fills[0] = 50 ether;
 
-    vm.expectRevert("taker overfill");
+    vm.expectRevert(MyriadCTFExchange.TakerOverfill.selector);
     exchange.matchMultipleOrdersWithFees(makers, makerSigs, fills, t, tSig);
 
     assertEq(exchange.filledAmounts(tHash), 60 ether, "taker fill unchanged after batch revert");
@@ -2494,7 +2494,7 @@ contract PredictionMarketCLOBTest is Test {
     bytes memory mSig = _signOrder(m, makerPk);
     bytes memory tSig = _signOrder(t, takerPk);
 
-    vm.expectRevert("insufficient collateral");
+    vm.expectRevert(MyriadCTFExchange.InsufficientCollateral.selector);
     exchange.matchOrdersWithFees(m, mSig, t, tSig, amount);
   }
 
@@ -2514,7 +2514,7 @@ contract PredictionMarketCLOBTest is Test {
     bytes memory mSig = _signOrder(m, makerPk);
     bytes memory tSig = _signOrder(t, takerPk);
 
-    vm.expectRevert("insufficient tokens");
+    vm.expectRevert(MyriadCTFExchange.InsufficientTokens.selector);
     exchange.matchOrdersWithFees(m, mSig, t, tSig, amount);
   }
 
@@ -2538,7 +2538,7 @@ contract PredictionMarketCLOBTest is Test {
     bytes memory mSig = _signOrder(m, makerPk);
     bytes memory tSig = _signOrder(t, takerPk);
 
-    vm.expectRevert("insufficient allowance");
+    vm.expectRevert(MyriadCTFExchange.InsufficientAllowance.selector);
     exchange.matchOrdersWithFees(m, mSig, t, tSig, amount);
   }
 
@@ -2560,7 +2560,7 @@ contract PredictionMarketCLOBTest is Test {
     bytes memory mSig = _signOrder(m, makerPk);
     bytes memory tSig = _signOrder(t, takerPk);
 
-    vm.expectRevert("insufficient collateral");
+    vm.expectRevert(MyriadCTFExchange.InsufficientCollateral.selector);
     exchange.matchOrdersWithFees(m, mSig, t, tSig, amount);
   }
 
@@ -2584,7 +2584,7 @@ contract PredictionMarketCLOBTest is Test {
     bytes memory mSig = _signOrder(m, makerPk);
     bytes memory tSig = _signOrder(t, takerPk);
 
-    vm.expectRevert("insufficient tokens");
+    vm.expectRevert(MyriadCTFExchange.InsufficientTokens.selector);
     exchange.matchOrdersWithFees(m, mSig, t, tSig, amount);
   }
 
@@ -2609,7 +2609,7 @@ contract PredictionMarketCLOBTest is Test {
     bytes memory mSig = _signOrder(m, makerPk);
     bytes memory tSig = _signOrder(t, takerPk);
 
-    vm.expectRevert("tokens not approved");
+    vm.expectRevert(MyriadCTFExchange.TokensNotApproved.selector);
     exchange.matchOrdersWithFees(m, mSig, t, tSig, amount);
   }
 
@@ -2632,7 +2632,7 @@ contract PredictionMarketCLOBTest is Test {
 
   function testSetMinOrderAmountNotAdminReverts() public {
     vm.prank(taker);
-    vm.expectRevert("not admin");
+    vm.expectRevert(MyriadCTFExchange.NotAdmin.selector);
     exchange.setMinOrderAmount(1 ether);
   }
 
@@ -2659,7 +2659,7 @@ contract PredictionMarketCLOBTest is Test {
     bytes memory mSig = _signOrder(m, makerPk);
     bytes memory tSig = _signOrder(t, takerPk);
 
-    vm.expectRevert("below min amount");
+    vm.expectRevert(MyriadCTFExchange.BelowMinAmount.selector);
     exchange.matchOrdersWithFees(m, mSig, t, tSig, 5 ether);
   }
 
@@ -2701,7 +2701,7 @@ contract PredictionMarketCLOBTest is Test {
     bytes memory mSig_ = _signOrder(m, makerPk);
     bytes memory tSig_ = _signOrder(t, takerPk);
 
-    vm.expectRevert("maker dust remainder");
+    vm.expectRevert(MyriadCTFExchange.MakerDustRemainder.selector);
     exchange.matchOrdersWithFees(m, mSig_, t, tSig_, 20 ether);
   }
 
@@ -2723,7 +2723,7 @@ contract PredictionMarketCLOBTest is Test {
     bytes memory mSig_ = _signOrder(m, makerPk);
     bytes memory tSig_ = _signOrder(t, takerPk);
 
-    vm.expectRevert("taker dust remainder");
+    vm.expectRevert(MyriadCTFExchange.TakerDustRemainder.selector);
     exchange.matchOrdersWithFees(m, mSig_, t, tSig_, 20 ether);
   }
 
@@ -2820,7 +2820,7 @@ contract PredictionMarketCLOBTest is Test {
     uint256 makerTokensBefore = conditionalTokens.balanceOf(maker, yesTokenId);
     uint256 takerColBefore = collateral.balanceOf(taker);
 
-    vm.expectRevert("taker dust remainder");
+    vm.expectRevert(MyriadCTFExchange.TakerDustRemainder.selector);
     exchange.matchOrdersWithFees(m, mSig, t, tSig, 60 ether);
 
     assertEq(conditionalTokens.balanceOf(maker, yesTokenId), makerTokensBefore, "maker tokens unchanged");
@@ -2854,7 +2854,7 @@ contract PredictionMarketCLOBTest is Test {
 
     uint256 makerColBefore = collateral.balanceOf(maker);
 
-    vm.expectRevert("taker overfill");
+    vm.expectRevert(MyriadCTFExchange.TakerOverfill.selector);
     exchange.matchOrdersWithFees(m1, m1Sig, t1, t1Sig, 10 ether);
 
     assertEq(collateral.balanceOf(maker), makerColBefore, "maker collateral unchanged after revert");
@@ -2876,7 +2876,7 @@ contract PredictionMarketCLOBTest is Test {
     bytes32 mHash = exchange.hashOrder(m);
     bytes32 tHash = exchange.hashOrder(t);
 
-    vm.expectRevert("insufficient tokens");
+    vm.expectRevert(MyriadCTFExchange.InsufficientTokens.selector);
     exchange.matchOrdersWithFees(m, mSig, t, tSig, 50 ether);
 
     assertEq(exchange.filledAmounts(tHash), 0, "taker fill rolled back");


### PR DESCRIPTION
## Summary

Optimizations and a correctness fix for `MyriadCTFExchange`.

### Custom errors

Replaced all `require(condition, "string message")` statements with `if (!condition) revert CustomError()` using dedicated custom error types. This improves gas efficiency and provides more structured revert data for off-chain consumers.

### Unchecked loop increments and helper functions

- Converted all `for` loop `i++` increments to `unchecked { ++i; }`, removing redundant overflow checks on bounded loop counters.
- Extracted `_requireAdmin()` and `_requireOperator()` internal view helpers, deduplicating the repeated `registry.hasRole(...)` pattern.

### Fix: relax mint/merge match price-sum constraint

- **`_settleMintMatch`** (both buyers): relaxed `price0 + price1 == 1e18` to `price0 + price1 >= 1e18`. The settlement already computes `takerNotional = fillAmount - makerNotional`, so the taker's cost is derived from the maker's price regardless of the exact sum. Requiring strict equality rejected valid matches where both parties were willing to trade.
- **`_settleMergeMatch`** (both sellers): relaxed `price0 + price1 == 1e18` to `price0 + price1 <= 1e18`. Same logic — `outcome1Notional = fillAmount - outcome0Notional`, so proceeds are split based on the maker's price. The constraint only needs to ensure the total doesn't exceed the collateral released by the merge.