### PR TITLE
fix(neg-risk): support progressive leg resolution before event close

### DIFF
--- a/contracts/MyriadCTFExchange.sol
+++ b/contracts/MyriadCTFExchange.sol
@@ -29,6 +29,7 @@ interface IFeeModule {
 interface INegRiskAdapter {
   function mintAllYesTokens(bytes32 eventId, uint256 amount, address recipient) external;
   function getEventOutcomeCount(bytes32 eventId) external view returns (uint256);
+  function getUnresolvedOutcomeCount(bytes32 eventId) external view returns (uint256);
   function underlying() external view returns (IERC20);
   function wrapForExchange(uint256 amount) external;
 }
@@ -389,7 +390,10 @@ contract MyriadCTFExchange is Initializable, ReentrancyGuardTransientUpgradeable
     if (eventId == bytes32(0)) revert NotNegRisk();
 
     {
-      uint256 expectedCount = INegRiskAdapter(_adapter).getEventOutcomeCount(eventId);
+      // Match orders only against unresolved legs — early-resolved legs are
+      // treated as if they never existed. The per-order `_requireMarketOpen`
+      // below additionally rejects any order naming a resolved market.
+      uint256 expectedCount = INegRiskAdapter(_adapter).getUnresolvedOutcomeCount(eventId);
       if (orders.length != expectedCount) revert MustMatchAllOutcomes();
     }
 

--- a/contracts/NegRiskAdapter.sol
+++ b/contracts/NegRiskAdapter.sol
@@ -246,21 +246,37 @@ contract NegRiskAdapter is ReentrancyGuardTransient, ERC1155Holder {
 
     uint256 n = evt.outcomeCount;
     uint256 noMarketId = evt.marketIds[noOutcomeIndex];
+    require(
+      manager.getMarketState(noMarketId) != IMyriadMarketManager.MarketState.resolved,
+      "leg resolved"
+    );
     uint256 noTokenId = conditionalTokens.getTokenId(noMarketId, Outcomes.NO);
+
+    // Count splittable legs (i != noOutcomeIndex AND not resolved).
+    // Resolved legs are treated as if they never existed — their YES would be
+    // worth 0, so skipping them costs the user nothing.
+    uint256 k;
+    for (uint256 i = 0; i < n; i++) {
+      if (i == noOutcomeIndex) continue;
+      if (manager.getMarketState(evt.marketIds[i]) == IMyriadMarketManager.MarketState.resolved) continue;
+      k++;
+    }
+    require(k > 0, "no unresolved legs");
 
     // Take NO(noOutcomeIndex) from caller
     conditionalTokens.safeTransferFrom(msg.sender, address(this), noTokenId, amount, "");
 
-    // Mint wcol for splitting in the other (N-1) markets
-    uint256 wcolToMint = (n - 1) * amount;
+    // Mint wcol for splitting in the K unresolved complementary markets
+    uint256 wcolToMint = k * amount;
     wcol.adapterMint(address(this), wcolToMint);
     mintedWcolPerEvent[eventId] += wcolToMint;
 
-    // Split in each other market and send YES to caller, keep NO
+    // Split in each unresolved other market and send YES to caller, keep NO
     for (uint256 i = 0; i < n; i++) {
       if (i == noOutcomeIndex) continue;
-
       uint256 marketId = evt.marketIds[i];
+      if (manager.getMarketState(marketId) == IMyriadMarketManager.MarketState.resolved) continue;
+
       conditionalTokens.splitPosition(marketId, amount);
 
       // Send YES to caller
@@ -292,27 +308,48 @@ contract NegRiskAdapter is ReentrancyGuardTransient, ERC1155Holder {
 
     uint256 n = evt.outcomeCount;
 
-    // Pull underlying from the exchange and wrap for the first market's split.
+    // Locate the first unresolved leg — it consumes the freshly-wrapped wcol.
+    // Resolved legs are skipped: YES on a resolved-NO leg is worth 0, so
+    // the recipient losing that share has no economic effect.
+    uint256 firstUnresolved = type(uint256).max;
+    for (uint256 i = 0; i < n; i++) {
+      if (manager.getMarketState(evt.marketIds[i]) != IMyriadMarketManager.MarketState.resolved) {
+        firstUnresolved = i;
+        break;
+      }
+    }
+    require(firstUnresolved != type(uint256).max, "no unresolved legs");
+
+    // Pull underlying from the exchange and wrap for the first unresolved market's split.
     underlying.safeTransferFrom(msg.sender, address(this), amount);
     underlying.forceApprove(address(wcol), amount);
     wcol.wrap(amount);
 
-    // Split first market using the freshly-wrapped wcol
+    // Split first unresolved market using the freshly-wrapped wcol
     {
-      uint256 marketId = evt.marketIds[0];
+      uint256 marketId = evt.marketIds[firstUnresolved];
       conditionalTokens.splitPosition(marketId, amount);
       uint256 yesTokenId = conditionalTokens.getTokenId(marketId, Outcomes.YES);
       conditionalTokens.safeTransferFrom(address(this), recipient, yesTokenId, amount, "");
     }
 
-    // Mint wcol for the remaining (N-1) markets and split each
-    if (n > 1) {
-      uint256 wcolToMint = (n - 1) * amount;
+    // Count remaining unresolved legs after firstUnresolved
+    uint256 remaining;
+    for (uint256 i = firstUnresolved + 1; i < n; i++) {
+      if (manager.getMarketState(evt.marketIds[i]) != IMyriadMarketManager.MarketState.resolved) {
+        remaining++;
+      }
+    }
+
+    // Mint wcol for the remaining unresolved markets and split each
+    if (remaining > 0) {
+      uint256 wcolToMint = remaining * amount;
       wcol.adapterMint(address(this), wcolToMint);
       mintedWcolPerEvent[eventId] += wcolToMint;
 
-      for (uint256 i = 1; i < n; i++) {
+      for (uint256 i = firstUnresolved + 1; i < n; i++) {
         uint256 marketId = evt.marketIds[i];
+        if (manager.getMarketState(marketId) == IMyriadMarketManager.MarketState.resolved) continue;
         conditionalTokens.splitPosition(marketId, amount);
         uint256 yesTokenId = conditionalTokens.getTokenId(marketId, Outcomes.YES);
         conditionalTokens.safeTransferFrom(address(this), recipient, yesTokenId, amount, "");
@@ -451,8 +488,11 @@ contract NegRiskAdapter is ReentrancyGuardTransient, ERC1155Holder {
     emit EventResolved(eventId, winningIndex);
   }
 
-  /// @notice Void the event with per-market YES payouts. Each market is voided
-  ///         via adminVoidMarket; NO payout is derived as 1e18 - yesPayout.
+  /// @notice Void the event with per-market YES payouts. Each unresolved market is
+  ///         voided via adminVoidMarket; NO payout is derived as 1e18 - yesPayout.
+  ///         Already-resolved legs (early NO via adminResolveEventMarket) are
+  ///         skipped and keep their existing resolution — their yesPayouts entry
+  ///         MUST be 0 to acknowledge the leg is not being voided.
   /// @param eventId The event identifier.
   /// @param yesPayouts Array of YES (outcome 0) payouts, one per market, in 1e18.
   function voidEvent(
@@ -471,6 +511,12 @@ contract NegRiskAdapter is ReentrancyGuardTransient, ERC1155Holder {
     uint256 totalYesPayout;
     for (uint256 i = 0; i < n; i++) {
       require(yesPayouts[i] <= 1e18, "yes payout > 1e18");
+      if (manager.getMarketState(evt.marketIds[i]) == IMyriadMarketManager.MarketState.resolved) {
+        // Already-NO-resolved legs (YES-resolved would have finalized the event
+        // via _forceOthersNoAndFinalize, so we cannot be here) keep their NO
+        // outcome — caller must pass 0 to acknowledge they are not being voided.
+        require(yesPayouts[i] == 0, "resolved leg payout != 0");
+      }
       totalYesPayout += yesPayouts[i];
     }
 
@@ -482,6 +528,7 @@ contract NegRiskAdapter is ReentrancyGuardTransient, ERC1155Holder {
     evt.winningIndex = -2;
 
     for (uint256 i = 0; i < n; i++) {
+      if (manager.getMarketState(evt.marketIds[i]) == IMyriadMarketManager.MarketState.resolved) continue;
       manager.adminVoidMarket(evt.marketIds[i], yesPayouts[i], 1e18 - yesPayouts[i]);
     }
 
@@ -556,6 +603,21 @@ contract NegRiskAdapter is ReentrancyGuardTransient, ERC1155Holder {
 
   function getEventOutcomeCount(bytes32 eventId) external view returns (uint256) {
     return _events[eventId].outcomeCount;
+  }
+
+  /// @notice Number of constituent markets that are NOT yet resolved.
+  ///         Early-resolved legs are excluded — multi-leg paths treat them
+  ///         as if they never existed.
+  function getUnresolvedOutcomeCount(bytes32 eventId) external view returns (uint256) {
+    Event storage evt = _events[eventId];
+    uint256 n = evt.outcomeCount;
+    uint256 count;
+    for (uint256 i = 0; i < n; i++) {
+      if (manager.getMarketState(evt.marketIds[i]) != IMyriadMarketManager.MarketState.resolved) {
+        count++;
+      }
+    }
+    return count;
   }
 
   function isEventResolved(bytes32 eventId) external view returns (bool) {

--- a/contracts/NegRiskAdapter.sol
+++ b/contracts/NegRiskAdapter.sol
@@ -56,6 +56,7 @@ contract NegRiskAdapter is ReentrancyGuardTransient, ERC1155Holder {
 
   event EventCreated(bytes32 indexed eventId, uint256 outcomeCount, uint256[] marketIds);
   event EventResolved(bytes32 indexed eventId, int256 winningIndex);
+  event EventMarketForcedNo(bytes32 indexed eventId, uint256 outcomeIndex, uint256 marketId);
   event EventVoided(bytes32 indexed eventId, uint256[] yesPayouts);
   event PositionsSplit(bytes32 indexed eventId, uint256 outcomeIndex, address indexed user, uint256 amount);
   event PositionsMerged(bytes32 indexed eventId, uint256 outcomeIndex, address indexed user, uint256 amount);
@@ -324,24 +325,28 @@ contract NegRiskAdapter is ReentrancyGuardTransient, ERC1155Holder {
   // ─── Resolution ──────────────────────────────────────────────────────
 
   /// @notice Permissionless per-market resolution for a neg-risk event. Routes
-  ///         through `manager.resolveMarket` and enforces the event-level
-  ///         "at most one YES per event" invariant.
+  ///         through `manager.resolveMarket`. When the resolved outcome is YES,
+  ///         atomically forces every other constituent market to NO and finalizes
+  ///         the event — encoding mutual exclusivity forward so a dual-YES race
+  ///         is structurally impossible.
   function resolveEventMarket(bytes32 eventId, uint256 outcomeIndex) external nonReentrant returns (int256) {
     Event storage evt = _events[eventId];
     require(evt.outcomeCount > 0, "event !exist");
+    require(!evt.resolved, "already resolved");
     require(outcomeIndex < evt.outcomeCount, "bad index");
 
     uint256 marketId = evt.marketIds[outcomeIndex];
     int256 outcome = manager.resolveMarket(marketId);
     if (outcome == int256(Outcomes.YES)) {
-      _requireNoOtherYes(evt, marketId);
+      _forceOthersNoAndFinalize(evt, eventId, outcomeIndex);
     }
     return outcome;
   }
 
   /// @notice Admin per-market override for a neg-risk event. Routes through
-  ///         `manager.adminResolveMarket` and enforces the event-level
-  ///         "at most one YES per event" invariant.
+  ///         `manager.adminResolveMarket`. When the supplied outcome is YES,
+  ///         atomically forces every other constituent market to NO and finalizes
+  ///         the event (same forward invariant as `resolveEventMarket`).
   function adminResolveEventMarket(
     bytes32 eventId,
     uint256 outcomeIndex,
@@ -351,24 +356,36 @@ contract NegRiskAdapter is ReentrancyGuardTransient, ERC1155Holder {
 
     Event storage evt = _events[eventId];
     require(evt.outcomeCount > 0, "event !exist");
+    require(!evt.resolved, "already resolved");
     require(outcomeIndex < evt.outcomeCount, "bad index");
 
     uint256 marketId = evt.marketIds[outcomeIndex];
+    int256 result = manager.adminResolveMarket(marketId, outcome);
     if (outcome == int256(Outcomes.YES)) {
-      _requireNoOtherYes(evt, marketId);
+      _forceOthersNoAndFinalize(evt, eventId, outcomeIndex);
     }
-    return manager.adminResolveMarket(marketId, outcome);
+    return result;
   }
 
-  function _requireNoOtherYes(Event storage evt, uint256 marketId) internal view {
+  /// @dev Force every constituent market other than `winnerIndex` to NO and
+  ///      finalize the event. Already-resolved markets are skipped (with a
+  ///      defense-in-depth check that they aren't YES — should be unreachable
+  ///      because the forward invariant prevents two YES from co-existing).
+  function _forceOthersNoAndFinalize(Event storage evt, bytes32 eventId, uint256 winnerIndex) internal {
     uint256 n = evt.marketIds.length;
     for (uint256 i = 0; i < n; i++) {
+      if (i == winnerIndex) continue;
       uint256 mid = evt.marketIds[i];
-      if (mid == marketId) continue;
-      if (manager.getMarketResolvedOutcome(mid) == int256(Outcomes.YES)) {
-        revert("event already has YES winner");
+      if (manager.getMarketState(mid) == IMyriadMarketManager.MarketState.resolved) {
+        require(manager.getMarketResolvedOutcome(mid) != int256(Outcomes.YES), "event already has YES winner");
+        continue;
       }
+      manager.adminResolveMarket(mid, int256(Outcomes.NO));
+      emit EventMarketForcedNo(eventId, i, mid);
     }
+    evt.resolved = true;
+    evt.winningIndex = int256(winnerIndex);
+    emit EventResolved(eventId, int256(winnerIndex));
   }
 
   /// @notice Permissionless event resolution. Derives `winningIndex` by scanning

--- a/test/NegRiskAdapter.t.sol
+++ b/test/NegRiskAdapter.t.sol
@@ -1333,13 +1333,17 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
   }
 
   function testAdminResolveEventMarketRejectsSecondYes() public {
-    (bytes32 eventId,) = _createThreeOutcomeEvent();
+    (bytes32 eventId, uint256[] memory marketIds) = _createThreeOutcomeEvent();
 
     vm.warp(block.timestamp + 2 days);
 
+    // First admin YES finalizes the event and force-resolves the other markets to NO.
     adapter.adminResolveEventMarket(eventId, 0, int256(Outcomes.YES));
+    assertEq(manager.getMarketResolvedOutcome(marketIds[1]), int256(Outcomes.NO));
+    assertEq(manager.getMarketResolvedOutcome(marketIds[2]), int256(Outcomes.NO));
 
-    vm.expectRevert("event already has YES winner");
+    // A second admin YES is rejected because the event is already finalized.
+    vm.expectRevert("already resolved");
     adapter.adminResolveEventMarket(eventId, 1, int256(Outcomes.YES));
   }
 
@@ -1352,9 +1356,12 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
     oracle.setResult(marketIds[0], int256(Outcomes.YES), true);
     oracle.setResult(marketIds[1], int256(Outcomes.YES), true);
 
+    // The first YES finalizes the event and force-resolves the second oracle's
+    // market to NO before the second call can even reach manager.resolveMarket.
     adapter.resolveEventMarket(eventId, 0);
+    assertEq(manager.getMarketResolvedOutcome(marketIds[1]), int256(Outcomes.NO));
 
-    vm.expectRevert("event already has YES winner");
+    vm.expectRevert("already resolved");
     adapter.resolveEventMarket(eventId, 1);
   }
 
@@ -1368,16 +1375,75 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
     adapter.adminResolveEventMarket(eventId, 0, int256(Outcomes.NO));
     adapter.adminResolveEventMarket(eventId, 1, int256(Outcomes.NO));
 
-    // Final winner emerges, oracle reports — resolve via permissionless path.
+    // Final winner emerges and the YES per-market call finalizes the event,
+    // force-resolving market 3 to NO atomically.
     oracle.setResult(marketIds[2], int256(Outcomes.YES), true);
-    oracle.setResult(marketIds[3], int256(Outcomes.NO), true);
     adapter.resolveEventMarket(eventId, 2);
-    adapter.resolveEventMarket(eventId, 3);
 
-    adapter.resolveEvent(eventId);
+    assertEq(manager.getMarketResolvedOutcome(marketIds[3]), int256(Outcomes.NO));
+
     (, bool resolved, int256 winningIndex,,) = adapter.getEvent(eventId);
     assertTrue(resolved);
     assertEq(winningIndex, 2);
+  }
+
+  function testResolveEventMarket_YesForcesOthersToNoAndFinalizes() public {
+    MockMarketOracle oracle = new MockMarketOracle();
+    (bytes32 eventId, uint256[] memory marketIds) = _createEventWithOracle(address(oracle), 3);
+
+    vm.warp(block.timestamp + 2 days);
+
+    oracle.setResult(marketIds[0], int256(Outcomes.YES), true);
+    adapter.resolveEventMarket(eventId, 0);
+
+    assertEq(manager.getMarketResolvedOutcome(marketIds[0]), int256(Outcomes.YES));
+    assertEq(manager.getMarketResolvedOutcome(marketIds[1]), int256(Outcomes.NO));
+    assertEq(manager.getMarketResolvedOutcome(marketIds[2]), int256(Outcomes.NO));
+
+    (, bool resolved, int256 winningIndex,,) = adapter.getEvent(eventId);
+    assertTrue(resolved);
+    assertEq(winningIndex, 0);
+  }
+
+  function testResolveEventMarket_PreResolvedNoIsNotReResolved() public {
+    MockMarketOracle oracle = new MockMarketOracle();
+    (bytes32 eventId, uint256[] memory marketIds) = _createEventWithOracle(address(oracle), 3);
+
+    vm.warp(block.timestamp + 2 days);
+
+    // Pre-resolve market 1 as NO via its oracle.
+    oracle.setResult(marketIds[1], int256(Outcomes.NO), true);
+    adapter.resolveEventMarket(eventId, 1);
+
+    // YES on market 0 should force market 2 to NO and skip the already-resolved market 1.
+    oracle.setResult(marketIds[0], int256(Outcomes.YES), true);
+    adapter.resolveEventMarket(eventId, 0);
+
+    assertEq(manager.getMarketResolvedOutcome(marketIds[0]), int256(Outcomes.YES));
+    assertEq(manager.getMarketResolvedOutcome(marketIds[1]), int256(Outcomes.NO));
+    assertEq(manager.getMarketResolvedOutcome(marketIds[2]), int256(Outcomes.NO));
+
+    (, bool resolved, int256 winningIndex,,) = adapter.getEvent(eventId);
+    assertTrue(resolved);
+    assertEq(winningIndex, 0);
+  }
+
+  function testResolveEventMarket_EmitsForcedNoForUnresolvedConstituents() public {
+    MockMarketOracle oracle = new MockMarketOracle();
+    (bytes32 eventId, uint256[] memory marketIds) = _createEventWithOracle(address(oracle), 3);
+
+    vm.warp(block.timestamp + 2 days);
+
+    oracle.setResult(marketIds[0], int256(Outcomes.YES), true);
+
+    vm.expectEmit(true, false, false, true);
+    emit NegRiskAdapter.EventMarketForcedNo(eventId, 1, marketIds[1]);
+    vm.expectEmit(true, false, false, true);
+    emit NegRiskAdapter.EventMarketForcedNo(eventId, 2, marketIds[2]);
+    vm.expectEmit(true, false, false, true);
+    emit NegRiskAdapter.EventResolved(eventId, 0);
+
+    adapter.resolveEventMarket(eventId, 0);
   }
 
   // =========================================================================
@@ -1394,16 +1460,17 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
     oracle.setResult(marketIds[1], int256(Outcomes.YES), true);
     oracle.setResult(marketIds[2], int256(Outcomes.NO), true);
     oracle.setResult(marketIds[3], int256(Outcomes.NO), true);
-    for (uint256 i = 0; i < 4; i++) {
-      adapter.resolveEventMarket(eventId, i);
-    }
 
-    vm.prank(alice);
-    adapter.resolveEvent(eventId);
+    // Resolve the NO market first, then the YES market — the YES call
+    // atomically force-resolves remaining markets (2, 3) to NO and finalizes.
+    adapter.resolveEventMarket(eventId, 0);
+    adapter.resolveEventMarket(eventId, 1);
 
     (, bool resolved, int256 winningIndex,,) = adapter.getEvent(eventId);
     assertTrue(resolved);
     assertEq(winningIndex, 1);
+    assertEq(manager.getMarketResolvedOutcome(marketIds[2]), int256(Outcomes.NO));
+    assertEq(manager.getMarketResolvedOutcome(marketIds[3]), int256(Outcomes.NO));
   }
 
   function testResolveEventPermissionless_NoYes_AllNo() public {
@@ -1437,9 +1504,11 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
     adapter.resolveEvent(eventId);
   }
 
-  /// @notice The adapter rejects the second YES at resolution time, so resolveEvent's
-  ///         "multiple YES" branch is unreachable through legitimate paths. This test
-  ///         verifies the rejection happens upstream in `resolveEventMarket`.
+  /// @notice The adapter encodes mutual exclusivity forward: the first YES
+  ///         finalizes the event and force-resolves the other markets to NO
+  ///         before any second YES oracle can ever land. The original wedge —
+  ///         where a dual-YES race left the second market permanently
+  ///         unresolvable — is structurally unreachable.
   function testResolveEventPermissionless_RejectsSecondYesUpstream() public {
     MockMarketOracle oracle = new MockMarketOracle();
     (bytes32 eventId, uint256[] memory marketIds) = _createEventWithOracle(address(oracle), 3);
@@ -1450,7 +1519,16 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
     oracle.setResult(marketIds[1], int256(Outcomes.YES), true);
     adapter.resolveEventMarket(eventId, 0);
 
-    vm.expectRevert("event already has YES winner");
+    // Second market was force-resolved to NO inside the first call; the event is finalized.
+    assertEq(manager.getMarketResolvedOutcome(marketIds[1]), int256(Outcomes.NO));
+    assertEq(manager.getMarketResolvedOutcome(marketIds[2]), int256(Outcomes.NO));
+
+    (, bool resolved, int256 winningIndex,,) = adapter.getEvent(eventId);
+    assertTrue(resolved);
+    assertEq(winningIndex, 0);
+
+    // A redundant second call is rejected because the event is already resolved.
+    vm.expectRevert("already resolved");
     adapter.resolveEventMarket(eventId, 1);
   }
 
@@ -1473,41 +1551,43 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
   // Admin event resolution overrides (Phase B)
   // =========================================================================
 
-  function testAdminResolveEvent_SkipsPreResolved() public {
+  function testAdminResolveEvent_FinalizesAllNoEvent() public {
     MockMarketOracle oracle = new MockMarketOracle();
     (bytes32 eventId, uint256[] memory marketIds) = _createEventWithOracle(address(oracle), 4);
 
     vm.warp(block.timestamp + 2 days);
 
-    // market 1 pre-resolved YES via per-market path
-    oracle.setResult(marketIds[1], int256(Outcomes.YES), true);
-    adapter.resolveEventMarket(eventId, 1);
+    // Markets 0 and 2 pre-resolved NO via per-market — event remains unresolved
+    // because there's no YES yet to trigger finalization.
+    oracle.setResult(marketIds[0], int256(Outcomes.NO), true);
+    oracle.setResult(marketIds[2], int256(Outcomes.NO), true);
+    adapter.resolveEventMarket(eventId, 0);
+    adapter.resolveEventMarket(eventId, 2);
 
-    // Admin agrees: outcome 1 wins
-    adapter.adminResolveEvent(eventId, 1);
+    // Admin finalizes with the all-NO ("Other won") outcome, force-resolving the rest.
+    adapter.adminResolveEvent(eventId, -1);
 
-    assertEq(manager.getMarketResolvedOutcome(marketIds[0]), int256(Outcomes.NO));
-    assertEq(manager.getMarketResolvedOutcome(marketIds[1]), int256(Outcomes.YES));
-    assertEq(manager.getMarketResolvedOutcome(marketIds[2]), int256(Outcomes.NO));
-    assertEq(manager.getMarketResolvedOutcome(marketIds[3]), int256(Outcomes.NO));
+    for (uint256 i = 0; i < 4; i++) {
+      assertEq(manager.getMarketResolvedOutcome(marketIds[i]), int256(Outcomes.NO));
+    }
 
     (, bool resolved, int256 winningIndex,,) = adapter.getEvent(eventId);
     assertTrue(resolved);
-    assertEq(winningIndex, 1);
+    assertEq(winningIndex, -1);
   }
 
-  function testAdminResolveEvent_RevertsOnDisagreement() public {
+  function testAdminResolveEvent_RevertsWhenEventAlreadyResolved() public {
     MockMarketOracle oracle = new MockMarketOracle();
     (bytes32 eventId, uint256[] memory marketIds) = _createEventWithOracle(address(oracle), 4);
 
     vm.warp(block.timestamp + 2 days);
 
-    // market 0 pre-resolved YES via per-market
+    // A per-market YES atomically finalizes the event — adminResolveEvent is no
+    // longer needed and would conflict with the already-resolved state.
     oracle.setResult(marketIds[0], int256(Outcomes.YES), true);
     adapter.resolveEventMarket(eventId, 0);
 
-    // Admin claims outcome 2 wins → conflict with market 0 = YES
-    vm.expectRevert("winningIndex conflicts with resolved market");
+    vm.expectRevert("already resolved");
     adapter.adminResolveEvent(eventId, 2);
   }
 
@@ -1556,24 +1636,18 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
 
     vm.warp(block.timestamp + 2 days);
 
-    // Outcome 2 wins. Resolve markets 0 and 3 per-market, leave 1 and 2 to resolveEvent.
+    // Outcome 2 wins. Resolve markets 0, 1, 3 as NO via per-market path; the
+    // YES on market 2 then finalizes the event and force-resolves anything
+    // remaining (none here — all NOs already in) to NO.
     oracle.setResult(marketIds[0], int256(Outcomes.NO), true);
+    oracle.setResult(marketIds[1], int256(Outcomes.NO), true);
     oracle.setResult(marketIds[2], int256(Outcomes.YES), true);
     oracle.setResult(marketIds[3], int256(Outcomes.NO), true);
     adapter.resolveEventMarket(eventId, 0);
-    adapter.resolveEventMarket(eventId, 3);
-
-    // Now market 1 is still open. resolveEvent would revert "market !resolved".
-    // Use per-market for market 1 too, then ratify with permissionless resolveEvent.
-    oracle.setResult(marketIds[1], int256(Outcomes.NO), true);
     adapter.resolveEventMarket(eventId, 1);
-
-    // The remaining one (market 2) gets resolved via resolveEvent? No — resolveEvent
-    // doesn't write per-market outcomes anymore. We resolve market 2 per-market too,
-    // then call resolveEvent to ratify event-level state.
+    adapter.resolveEventMarket(eventId, 3);
     adapter.resolveEventMarket(eventId, 2);
 
-    adapter.resolveEvent(eventId);
     (,, int256 winningIndex,,) = adapter.getEvent(eventId);
     assertEq(winningIndex, 2);
 
@@ -1595,6 +1669,44 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
     // Treasury should have received nothing extra: alice's deposit (amount) flowed through
     // the YES(2) winning side. The 3 NO redemptions netted exactly the 3*amount minted.
     assertEq(collateral.balanceOf(treasury), 0);
+  }
+
+  /// @notice Original audit scenario: two oracles independently return YES for
+  ///         mutually exclusive constituents (an upstream invariant violation).
+  ///         The forward-invariant fix ensures the first YES finalizes the event
+  ///         and forces the others to NO, so `redeemNOPositions` runs without any
+  ///         admin intervention.
+  function testRedeemNOPositions_WorksAfterDualYesScenario() public {
+    MockMarketOracle oracle = new MockMarketOracle();
+    (bytes32 eventId, uint256[] memory marketIds) = _createEventWithOracle(address(oracle), 3);
+    uint256 amount = 100 ether;
+
+    // Alice creates NO positions in the adapter via split + convert.
+    collateral.mint(alice, amount);
+    vm.startPrank(alice);
+    collateral.approve(address(adapter), amount);
+    adapter.splitPosition(eventId, 0, amount);
+    conditionalTokens.setApprovalForAll(address(adapter), true);
+    adapter.convertPositions(eventId, 0, amount);
+    vm.stopPrank();
+
+    vm.warp(block.timestamp + 2 days);
+
+    // Two oracles report YES for the same event — the upstream fault scenario.
+    oracle.setResult(marketIds[0], int256(Outcomes.YES), true);
+    oracle.setResult(marketIds[1], int256(Outcomes.YES), true);
+
+    // First-mover wins: m0 YES, m1 and m2 forced NO atomically, event finalized.
+    adapter.resolveEventMarket(eventId, 0);
+
+    (, bool resolved, int256 winningIndex,,) = adapter.getEvent(eventId);
+    assertTrue(resolved);
+    assertEq(winningIndex, 0);
+
+    // The previously-wedging redeemNOPositions call now succeeds with no admin.
+    adapter.redeemNOPositions(eventId);
+    assertTrue(adapter.noPositionsRedeemed(eventId));
+    assertEq(adapter.mintedWcolPerEvent(eventId), 0);
   }
 
   // =========================================================================

--- a/test/NegRiskAdapter.t.sol
+++ b/test/NegRiskAdapter.t.sol
@@ -246,10 +246,9 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
     (bytes32 eventId, uint256[] memory marketIds) = _createThreeOutcomeEvent();
     uint256 amount = 50 ether;
 
-    // Admin early-resolves market 2 as NO (e.g., candidate dropped out).
-    vm.warp(block.timestamp + 2 days);
+    // Admin early-resolves market 2 as NO BEFORE close, e.g. "candidate dropped
+    // out in the group stage". Siblings remain open for trading.
     adapter.adminResolveEventMarket(eventId, 2, int256(Outcomes.NO));
-    // Reset timestamp does not matter — the leg is already resolved.
 
     // Alice splits in outcome 0, then converts NO(0) → YES on the remaining
     // unresolved sibling only (market 1). Market 2 is skipped.
@@ -274,8 +273,7 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
     (bytes32 eventId,) = _createThreeOutcomeEvent();
     uint256 amount = 10 ether;
 
-    // Admin early-resolves outcome 0 as NO.
-    vm.warp(block.timestamp + 2 days);
+    // Admin early-resolves outcome 0 as NO (before close).
     adapter.adminResolveEventMarket(eventId, 0, int256(Outcomes.NO));
 
     vm.prank(alice);
@@ -287,8 +285,7 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
     (bytes32 eventId,) = _createThreeOutcomeEvent();
     uint256 amount = 10 ether;
 
-    // Admin early-resolves both sibling legs to NO.
-    vm.warp(block.timestamp + 2 days);
+    // Admin early-resolves both sibling legs to NO (before close).
     adapter.adminResolveEventMarket(eventId, 1, int256(Outcomes.NO));
     adapter.adminResolveEventMarket(eventId, 2, int256(Outcomes.NO));
 
@@ -332,8 +329,7 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
     (bytes32 eventId, uint256[] memory marketIds) = _createThreeOutcomeEvent();
     uint256 amount = 30 ether;
 
-    // Admin early-resolves market 0 as NO.
-    vm.warp(block.timestamp + 2 days);
+    // Admin early-resolves market 0 as NO (before close).
     adapter.adminResolveEventMarket(eventId, 0, int256(Outcomes.NO));
 
     collateral.mint(address(exchange), amount);
@@ -355,7 +351,6 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
     (bytes32 eventId,) = _createThreeOutcomeEvent();
     uint256 amount = 10 ether;
 
-    vm.warp(block.timestamp + 2 days);
     adapter.adminResolveEventMarket(eventId, 0, int256(Outcomes.NO));
     adapter.adminResolveEventMarket(eventId, 1, int256(Outcomes.NO));
     adapter.adminResolveEventMarket(eventId, 2, int256(Outcomes.NO));
@@ -373,7 +368,6 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
     (bytes32 eventId,) = _createThreeOutcomeEvent();
     assertEq(adapter.getUnresolvedOutcomeCount(eventId), 3);
 
-    vm.warp(block.timestamp + 2 days);
     adapter.adminResolveEventMarket(eventId, 1, int256(Outcomes.NO));
     assertEq(adapter.getUnresolvedOutcomeCount(eventId), 2);
 
@@ -559,8 +553,7 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
       _setUniformFees(marketIds[i], 0, 0);
     }
 
-    // Admin early-resolves market 2 as NO before any trading.
-    vm.warp(block.timestamp + 2 days);
+    // Admin early-resolves market 2 as NO before close. Siblings remain tradeable.
     adapter.adminResolveEventMarket(eventId, 2, int256(Outcomes.NO));
 
     // Two buyers cover the remaining unresolved legs (markets 0 and 1).
@@ -609,8 +602,7 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
       _setUniformFees(marketIds[i], 0, 0);
     }
 
-    // Admin early-resolves market 2.
-    vm.warp(block.timestamp + 2 days);
+    // Admin early-resolves market 2 (before close).
     adapter.adminResolveEventMarket(eventId, 2, int256(Outcomes.NO));
 
     // Operator mistakenly submits orders for all 3 outcomes.

--- a/test/NegRiskAdapter.t.sol
+++ b/test/NegRiskAdapter.t.sol
@@ -242,6 +242,61 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
     assertEq(adapter.mintedWcolPerEvent(eventId), 2 * amount);
   }
 
+  function testConvertPositionsSkipsResolvedLeg() public {
+    (bytes32 eventId, uint256[] memory marketIds) = _createThreeOutcomeEvent();
+    uint256 amount = 50 ether;
+
+    // Admin early-resolves market 2 as NO (e.g., candidate dropped out).
+    vm.warp(block.timestamp + 2 days);
+    adapter.adminResolveEventMarket(eventId, 2, int256(Outcomes.NO));
+    // Reset timestamp does not matter — the leg is already resolved.
+
+    // Alice splits in outcome 0, then converts NO(0) → YES on the remaining
+    // unresolved sibling only (market 1). Market 2 is skipped.
+    collateral.mint(alice, amount);
+    vm.startPrank(alice);
+    collateral.approve(address(adapter), amount);
+    adapter.splitPosition(eventId, 0, amount);
+    conditionalTokens.setApprovalForAll(address(adapter), true);
+    adapter.convertPositions(eventId, 0, amount);
+    vm.stopPrank();
+
+    // Alice has YES(0) (from split) + YES(1) (from convert). She does NOT have YES(2).
+    assertEq(conditionalTokens.balanceOf(alice, conditionalTokens.getTokenId(marketIds[0], Outcomes.YES)), amount);
+    assertEq(conditionalTokens.balanceOf(alice, conditionalTokens.getTokenId(marketIds[1], Outcomes.YES)), amount);
+    assertEq(conditionalTokens.balanceOf(alice, conditionalTokens.getTokenId(marketIds[2], Outcomes.YES)), 0);
+
+    // wcol minted only for the K=1 unresolved sibling (was 2 in the all-open case).
+    assertEq(adapter.mintedWcolPerEvent(eventId), amount);
+  }
+
+  function testConvertPositionsRevertsIfUserLegResolved() public {
+    (bytes32 eventId,) = _createThreeOutcomeEvent();
+    uint256 amount = 10 ether;
+
+    // Admin early-resolves outcome 0 as NO.
+    vm.warp(block.timestamp + 2 days);
+    adapter.adminResolveEventMarket(eventId, 0, int256(Outcomes.NO));
+
+    vm.prank(alice);
+    vm.expectRevert("leg resolved");
+    adapter.convertPositions(eventId, 0, amount);
+  }
+
+  function testConvertPositionsRevertsIfAllOthersResolved() public {
+    (bytes32 eventId,) = _createThreeOutcomeEvent();
+    uint256 amount = 10 ether;
+
+    // Admin early-resolves both sibling legs to NO.
+    vm.warp(block.timestamp + 2 days);
+    adapter.adminResolveEventMarket(eventId, 1, int256(Outcomes.NO));
+    adapter.adminResolveEventMarket(eventId, 2, int256(Outcomes.NO));
+
+    vm.prank(alice);
+    vm.expectRevert("no unresolved legs");
+    adapter.convertPositions(eventId, 0, amount);
+  }
+
   // =========================================================================
   // MintAllYesTokens (used by exchange for cross-market matching)
   // =========================================================================
@@ -271,6 +326,59 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
 
     // Minted = (3-1) * 30 = 60 ether
     assertEq(adapter.mintedWcolPerEvent(eventId), 2 * amount);
+  }
+
+  function testMintAllYesTokensSkipsResolvedLeg() public {
+    (bytes32 eventId, uint256[] memory marketIds) = _createThreeOutcomeEvent();
+    uint256 amount = 30 ether;
+
+    // Admin early-resolves market 0 as NO.
+    vm.warp(block.timestamp + 2 days);
+    adapter.adminResolveEventMarket(eventId, 0, int256(Outcomes.NO));
+
+    collateral.mint(address(exchange), amount);
+    vm.startPrank(address(exchange));
+    collateral.approve(address(adapter), amount);
+    adapter.mintAllYesTokens(eventId, amount, address(exchange));
+    vm.stopPrank();
+
+    // Exchange has YES on markets 1 and 2; not on the resolved market 0.
+    assertEq(conditionalTokens.balanceOf(address(exchange), conditionalTokens.getTokenId(marketIds[0], Outcomes.YES)), 0);
+    assertEq(conditionalTokens.balanceOf(address(exchange), conditionalTokens.getTokenId(marketIds[1], Outcomes.YES)), amount);
+    assertEq(conditionalTokens.balanceOf(address(exchange), conditionalTokens.getTokenId(marketIds[2], Outcomes.YES)), amount);
+
+    // Minted = (K-1) * amount where K=2 unresolved legs → 1 * amount.
+    assertEq(adapter.mintedWcolPerEvent(eventId), amount);
+  }
+
+  function testMintAllYesTokensRevertsIfAllResolved() public {
+    (bytes32 eventId,) = _createThreeOutcomeEvent();
+    uint256 amount = 10 ether;
+
+    vm.warp(block.timestamp + 2 days);
+    adapter.adminResolveEventMarket(eventId, 0, int256(Outcomes.NO));
+    adapter.adminResolveEventMarket(eventId, 1, int256(Outcomes.NO));
+    adapter.adminResolveEventMarket(eventId, 2, int256(Outcomes.NO));
+
+    collateral.mint(address(exchange), amount);
+    vm.prank(address(exchange));
+    collateral.approve(address(adapter), amount);
+
+    vm.prank(address(exchange));
+    vm.expectRevert("no unresolved legs");
+    adapter.mintAllYesTokens(eventId, amount, address(exchange));
+  }
+
+  function testGetUnresolvedOutcomeCount() public {
+    (bytes32 eventId,) = _createThreeOutcomeEvent();
+    assertEq(adapter.getUnresolvedOutcomeCount(eventId), 3);
+
+    vm.warp(block.timestamp + 2 days);
+    adapter.adminResolveEventMarket(eventId, 1, int256(Outcomes.NO));
+    assertEq(adapter.getUnresolvedOutcomeCount(eventId), 2);
+
+    adapter.adminResolveEventMarket(eventId, 2, int256(Outcomes.NO));
+    assertEq(adapter.getUnresolvedOutcomeCount(eventId), 1);
   }
 
   // =========================================================================
@@ -441,6 +549,88 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
 
     vm.expectRevert(MyriadCTFExchange.PriceSumBelowOne.selector);
     exchange.matchCrossMarketOrders(orders, sigs, 10 ether);
+  }
+
+  function testCrossMarketMatchSkipsEarlyResolvedLeg() public {
+    (bytes32 eventId, uint256[] memory marketIds) = _createThreeOutcomeEvent();
+    uint256 amount = 100 ether;
+
+    for (uint256 i = 0; i < 3; i++) {
+      _setUniformFees(marketIds[i], 0, 0);
+    }
+
+    // Admin early-resolves market 2 as NO before any trading.
+    vm.warp(block.timestamp + 2 days);
+    adapter.adminResolveEventMarket(eventId, 2, int256(Outcomes.NO));
+
+    // Two buyers cover the remaining unresolved legs (markets 0 and 1).
+    uint256 fundAmount = 500 ether;
+    address[2] memory users = [alice, bob];
+    uint256[2] memory pks = [alicePk, bobPk];
+    for (uint256 i = 0; i < 2; i++) {
+      collateral.mint(users[i], fundAmount);
+      vm.startPrank(users[i]);
+      collateral.approve(address(exchange), type(uint256).max);
+      conditionalTokens.setApprovalForAll(address(exchange), true);
+      vm.stopPrank();
+    }
+
+    // Parity on the unresolved subset only: 0.55 + 0.45 = 1.00.
+    uint256 price0 = (55 * ONE) / 100;
+    uint256 price1 = (45 * ONE) / 100;
+
+    MyriadCTFExchange.Order[] memory orders = new MyriadCTFExchange.Order[](2);
+    orders[0] = _buildOrder(alice, marketIds[0], Outcomes.YES, MyriadCTFExchange.Side.Buy, amount, price0, 100);
+    orders[1] = _buildOrder(bob,   marketIds[1], Outcomes.YES, MyriadCTFExchange.Side.Buy, amount, price1, 101);
+
+    bytes[] memory sigs = new bytes[](2);
+    sigs[0] = _signOrder(orders[0], alicePk);
+    sigs[1] = _signOrder(orders[1], bobPk);
+
+    exchange.matchCrossMarketOrders(orders, sigs, amount);
+
+    // Each buyer received YES tokens for their respective leg.
+    assertEq(conditionalTokens.balanceOf(alice, conditionalTokens.getTokenId(marketIds[0], Outcomes.YES)), amount);
+    assertEq(conditionalTokens.balanceOf(bob,   conditionalTokens.getTokenId(marketIds[1], Outcomes.YES)), amount);
+
+    // No YES was minted for the early-resolved market 2.
+    assertEq(conditionalTokens.balanceOf(address(exchange), conditionalTokens.getTokenId(marketIds[2], Outcomes.YES)), 0);
+    assertEq(conditionalTokens.balanceOf(address(adapter),  conditionalTokens.getTokenId(marketIds[2], Outcomes.YES)), 0);
+
+    // wcol minted for the (K-1)=1 sibling.
+    assertEq(adapter.mintedWcolPerEvent(eventId), amount);
+  }
+
+  function testCrossMarketMatchRejectsFullOrderSetOnPartiallyResolvedEvent() public {
+    (bytes32 eventId, uint256[] memory marketIds) = _createThreeOutcomeEvent();
+    uint256 amount = 10 ether;
+
+    for (uint256 i = 0; i < 3; i++) {
+      _setUniformFees(marketIds[i], 0, 0);
+    }
+
+    // Admin early-resolves market 2.
+    vm.warp(block.timestamp + 2 days);
+    adapter.adminResolveEventMarket(eventId, 2, int256(Outcomes.NO));
+
+    // Operator mistakenly submits orders for all 3 outcomes.
+    uint256 price0 = (40 * ONE) / 100;
+    uint256 price1 = (30 * ONE) / 100;
+    uint256 price2 = (30 * ONE) / 100;
+
+    MyriadCTFExchange.Order[] memory orders = new MyriadCTFExchange.Order[](3);
+    orders[0] = _buildOrder(alice,   marketIds[0], Outcomes.YES, MyriadCTFExchange.Side.Buy, amount, price0, 1);
+    orders[1] = _buildOrder(bob,     marketIds[1], Outcomes.YES, MyriadCTFExchange.Side.Buy, amount, price1, 2);
+    orders[2] = _buildOrder(charlie, marketIds[2], Outcomes.YES, MyriadCTFExchange.Side.Buy, amount, price2, 3);
+
+    bytes[] memory sigs = new bytes[](3);
+    sigs[0] = _signOrder(orders[0], alicePk);
+    sigs[1] = _signOrder(orders[1], bobPk);
+    sigs[2] = _signOrder(orders[2], charliePk);
+
+    // unresolvedCount == 2 but orders.length == 3.
+    vm.expectRevert(MyriadCTFExchange.MustMatchAllOutcomes.selector);
+    exchange.matchCrossMarketOrders(orders, sigs, amount);
   }
 
   // =========================================================================
@@ -1591,25 +1781,60 @@ contract NegRiskAdapterTest is Test, ERC1155Holder {
     adapter.adminResolveEvent(eventId, 2);
   }
 
-  function testVoidEventStillStrict() public {
+  function testVoidEventRejectsNonZeroPayoutForResolvedLeg() public {
     MockMarketOracle oracle = new MockMarketOracle();
     (bytes32 eventId, uint256[] memory marketIds) = _createEventWithOracle(address(oracle), 3);
 
     vm.warp(block.timestamp + 2 days);
 
-    // market 0 pre-resolved
+    // market 0 pre-resolved NO
     oracle.setResult(marketIds[0], int256(Outcomes.NO), true);
     adapter.resolveEventMarket(eventId, 0);
 
-    // Sum to ONE so the solvency check passes and the loop reaches market 0.
+    // Caller must pass 0 for the resolved leg — non-zero is a contract violation.
     uint256[] memory yesPayouts = new uint256[](3);
     yesPayouts[0] = ONE / 2;
     yesPayouts[1] = ONE / 4;
     yesPayouts[2] = ONE / 4;
 
-    // adminVoidMarket on the already-resolved market 0 reverts inside the loop
-    vm.expectRevert("resolved");
+    vm.expectRevert("resolved leg payout != 0");
     adapter.voidEvent(eventId, yesPayouts);
+  }
+
+  function testVoidEventSkipsAlreadyResolvedLeg() public {
+    MockMarketOracle oracle = new MockMarketOracle();
+    (bytes32 eventId, uint256[] memory marketIds) = _createEventWithOracle(address(oracle), 3);
+
+    vm.warp(block.timestamp + 2 days);
+
+    // market 0 pre-resolved NO
+    oracle.setResult(marketIds[0], int256(Outcomes.NO), true);
+    adapter.resolveEventMarket(eventId, 0);
+
+    // Void the remaining two legs with custom payouts; resolved leg's slot is 0.
+    uint256[] memory yesPayouts = new uint256[](3);
+    yesPayouts[0] = 0;
+    yesPayouts[1] = (60 * ONE) / 100;
+    yesPayouts[2] = (40 * ONE) / 100;
+
+    adapter.voidEvent(eventId, yesPayouts);
+
+    // Pre-resolved leg keeps its NO outcome
+    assertEq(manager.getMarketResolvedOutcome(marketIds[0]), int256(Outcomes.NO));
+
+    // Other legs become voided with the supplied payouts
+    assertEq(manager.getMarketResolvedOutcome(marketIds[1]), -1);
+    assertEq(manager.getMarketResolvedOutcome(marketIds[2]), -1);
+    (uint256 out0Pay1, uint256 out1Pay1) = manager.getVoidedPayouts(marketIds[1]);
+    assertEq(out0Pay1, (60 * ONE) / 100);
+    assertEq(out1Pay1, (40 * ONE) / 100);
+    (uint256 out0Pay2, uint256 out1Pay2) = manager.getVoidedPayouts(marketIds[2]);
+    assertEq(out0Pay2, (40 * ONE) / 100);
+    assertEq(out1Pay2, (60 * ONE) / 100);
+
+    (, bool resolved, int256 winningIndex,,) = adapter.getEvent(eventId);
+    assertTrue(resolved);
+    assertEq(winningIndex, -2);
   }
 
   // =========================================================================


### PR DESCRIPTION
## Fix neg-risk progressive resolution (Cyfrin [#3](https://github.com/Cyfrin/audit-2026-06-myriad-pr151/issues/3), [#4](https://github.com/Cyfrin/audit-2026-06-myriad-pr151/issues/4), [#13](https://github.com/Cyfrin/audit-2026-06-myriad-pr151/issues/13))

Adds support for **progressive leg resolution** — constituent markets can resolve before the event's shared `closesAt` (required for long-running events like "Who wins the World Cup?", where outcomes are eliminated mid-tournament). All multi-leg paths now treat resolved legs as if they never existed, and YES resolution is made atomic.

### [#4](https://github.com/Cyfrin/audit-2026-06-myriad-pr151/issues/4) — dual-YES wedge
`resolveEventMarket`/`adminResolveEventMarket` now call `_forceOthersNoAndFinalize` when a leg resolves YES: every other leg is forced to NO and the event is finalized in the same tx. A second YES can never be recorded, so the event can't wedge. Replaces the old reactive `_requireNoOtherYes` revert.

### [#13](https://github.com/Cyfrin/audit-2026-06-myriad-pr151/issues/13) — early-resolved leg breaks void/convert/cross-market
Instead of gating resolution behind `closesAt` (which would break progressive elimination), every multi-leg path now **skips resolved legs**:
- `convertPositions` / `mintAllYesTokens` split only unresolved legs and mint wcol for those (`k`/`remaining`, not `n-1`).
- `matchCrossMarketOrders` sizes the bundle to `getUnresolvedOutcomeCount` (new view); resolved legs are excluded.
- `voidEvent` skips resolved legs.

A resolved leg (worth 0 on its YES side) no longer reverts these flows.

### [#3](https://github.com/Cyfrin/audit-2026-06-myriad-pr151/issues/3) — permissionless resolve forecloses `voidEvent`
`voidEvent` now tolerates already-resolved **NO** legs: it skips them and requires their `yesPayouts[i] == 0` (they keep their existing NO outcome). An early NO resolution no longer bricks the void escape hatch — the admin can still void the remaining legs. A YES resolution finalizes the event by design (a determinate winner exists), so void is intentionally closed in that case.

### Design note
The `closesAt`/cooldown gates recommended in #3 and #13 were **deliberately not adopted** — they'd prevent resolving eliminated legs before the event's `closesAt`, which is a hard requirement (World Cup elimination). The skip-resolved-legs architecture is the only approach compatible with that.

**Known residual (accepted):** a *definitive YES winner that is later contested/overturned* cannot be voided. Out of scope for the current threat model.

### Solvency
The minted-wcol invariant `recovered ≥ minted` is preserved: each convert/mint keeps one real-backed NO beyond its minted-backed NOs, so the single YES winner can never strip more backing than exists. A YES leg always sets `evt.resolved = true`, so a YES leg can never coexist with a void (no double-payout).

### Tests
Added coverage for: skip-resolved-leg in convert/mint/cross-market, dual-YES → first-wins-others-forced-NO, void-skips-resolved-leg + non-zero-payout rejection, `redeemNOPositions` after dual-YES, and `getUnresolvedOutcomeCount`.