### PR TITLE
CRE oracles for crypto/sports

### DIFF
--- a/contracts/oracles/CREReceiverBase.sol
+++ b/contracts/oracles/CREReceiverBase.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import {ICREReceiver} from "./ICREReceiver.sol";
+import {AdminRegistry} from "../AdminRegistry.sol";
+
+/// @title CREReceiverBase
+/// @notice Abstract base for Chainlink CRE receivers. Mirrors the pattern in
+///         Chainlink's `ReceiverTemplate`: settable expected values, opt-in
+///         per-field validation (a check is enforced only if the expected
+///         value is non-zero), and admin-gated rotation.
+/// @dev    The forwarder check is always enforced once a forwarder is set.
+///         Author and workflow-name checks are opt-in. Workflow id is stored
+///         for traceability but never enforced (it changes on every workflow
+///         recompile, so enforcing it would couple on-chain contracts to
+///         off-chain code releases).
+abstract contract CREReceiverBase is ICREReceiver {
+  // ─── Storage ─────────────────────────────────────────────────────────
+
+  AdminRegistry public immutable registry;
+
+  address private s_forwarder;
+  address private s_expectedAuthor;
+  bytes10 private s_expectedWorkflowName;
+  bytes32 private s_expectedWorkflowId; // stored for traceability, never enforced
+
+  // ─── Events ──────────────────────────────────────────────────────────
+
+  event ForwarderUpdated(address indexed previous, address indexed current);
+  event ExpectedAuthorUpdated(address indexed previous, address indexed current);
+  event ExpectedWorkflowNameUpdated(bytes10 indexed previous, bytes10 indexed current);
+  event ExpectedWorkflowIdUpdated(bytes32 indexed previous, bytes32 indexed current);
+
+  // ─── Errors ──────────────────────────────────────────────────────────
+
+  error UnauthorizedSender(address sender, address expected);
+  error UnauthorizedAuthor(address received, address expected);
+  error UnauthorizedWorkflowName(bytes10 received, bytes10 expected);
+
+  // ─── Modifier ────────────────────────────────────────────────────────
+
+  modifier onlyAdmin() {
+    require(registry.hasRole(registry.MARKET_ADMIN_ROLE(), msg.sender), "not admin");
+    _;
+  }
+
+  // ─── Constructor ─────────────────────────────────────────────────────
+
+  constructor(AdminRegistry _registry, address _forwarder) {
+    require(address(_registry) != address(0), "registry 0");
+    require(_forwarder != address(0), "forwarder 0");
+    registry = _registry;
+    s_forwarder = _forwarder;
+    emit ForwarderUpdated(address(0), _forwarder);
+  }
+
+  // ─── Getters ─────────────────────────────────────────────────────────
+
+  function getForwarder() external view returns (address) {
+    return s_forwarder;
+  }
+
+  function getExpectedAuthor() external view returns (address) {
+    return s_expectedAuthor;
+  }
+
+  function getExpectedWorkflowName() external view returns (bytes10) {
+    return s_expectedWorkflowName;
+  }
+
+  function getExpectedWorkflowId() external view returns (bytes32) {
+    return s_expectedWorkflowId;
+  }
+
+  // ─── Setters (admin-gated) ───────────────────────────────────────────
+
+  function setForwarder(address forwarder) external onlyAdmin {
+    require(forwarder != address(0), "forwarder 0");
+    address previous = s_forwarder;
+    s_forwarder = forwarder;
+    emit ForwarderUpdated(previous, forwarder);
+  }
+
+  function setExpectedAuthor(address author) external onlyAdmin {
+    address previous = s_expectedAuthor;
+    s_expectedAuthor = author;
+    emit ExpectedAuthorUpdated(previous, author);
+  }
+
+  function setExpectedWorkflowName(bytes10 name) external onlyAdmin {
+    bytes10 previous = s_expectedWorkflowName;
+    s_expectedWorkflowName = name;
+    emit ExpectedWorkflowNameUpdated(previous, name);
+  }
+
+  function setExpectedWorkflowId(bytes32 id) external onlyAdmin {
+    bytes32 previous = s_expectedWorkflowId;
+    s_expectedWorkflowId = id;
+    emit ExpectedWorkflowIdUpdated(previous, id);
+  }
+
+  // ─── Validation ──────────────────────────────────────────────────────
+
+  /// @dev Subclass `onReport()` MUST call this first. Forwarder check is
+  ///      always enforced; author / workflow-name checks are opt-in.
+  function _validate(bytes calldata metadata) internal view {
+    if (msg.sender != s_forwarder) revert UnauthorizedSender(msg.sender, s_forwarder);
+
+    address expectedAuthor = s_expectedAuthor;
+    bytes10 expectedName = s_expectedWorkflowName;
+
+    // Skip metadata decode if no opt-in checks are enabled
+    if (expectedAuthor == address(0) && expectedName == bytes10(0)) return;
+
+    (, bytes10 name, address author) = _decodeMetadata(metadata);
+
+    if (expectedAuthor != address(0) && author != expectedAuthor) {
+      revert UnauthorizedAuthor(author, expectedAuthor);
+    }
+    if (expectedName != bytes10(0) && name != expectedName) {
+      revert UnauthorizedWorkflowName(name, expectedName);
+    }
+  }
+
+  /// @dev Chainlink CRE metadata layout (TIGHTLY PACKED, 62 bytes):
+  ///        [0:32]  workflowId    (bytes32)
+  ///        [32:42] workflowName  (bytes10)
+  ///        [42:62] workflowOwner (address, 20 bytes)
+  function _decodeMetadata(bytes calldata metadata)
+    internal
+    pure
+    returns (bytes32 workflowId, bytes10 workflowName, address workflowOwner)
+  {
+    require(metadata.length >= 62, "metadata too short");
+    assembly {
+      let base := metadata.offset
+      workflowId := calldataload(base)
+      workflowName := and(
+        calldataload(add(base, 32)),
+        0xFFFFFFFFFFFFFFFFFFFF00000000000000000000000000000000000000000000
+      )
+      workflowOwner := shr(96, calldataload(add(base, 42)))
+    }
+  }
+
+  // ─── ERC165 ──────────────────────────────────────────────────────────
+
+  function supportsInterface(bytes4 interfaceId) public pure virtual override returns (bool) {
+    return interfaceId == type(ICREReceiver).interfaceId || interfaceId == type(IERC165).interfaceId;
+  }
+}

--- a/contracts/oracles/CryptoCREOracle.sol
+++ b/contracts/oracles/CryptoCREOracle.sol
@@ -1,0 +1,585 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import "../IMarketOracle.sol";
+import "../Outcomes.sol";
+import {CREReceiverBase} from "./CREReceiverBase.sol";
+import {AdminRegistry} from "../AdminRegistry.sol";
+
+interface ICREOracleManagerView {
+  function getMarketClosesAt(uint256 marketId) external view returns (uint256);
+}
+
+/// @title CryptoCREOracle
+/// @notice IMarketOracle + ICREReceiver implementation for deterministic crypto markets.
+///         Receives verified price data from a Chainlink CRE workflow via onReport(),
+///         stores it immutably, and computes binary market outcomes on-chain via getResult().
+///
+///         Supports 9 rule types with a yesAbove flag:
+///           THRESHOLD              — close vs fixed price
+///           DIRECTION              — close vs open (same feed)
+///           CHANGE_PCT             — |% change| vs bps threshold (volatility)
+///           RELATIVE               — feed A's % change vs feed B's % change
+///           HIT                    — did high/low reach a target at any point
+///           CANDLE                 — more green or red candles in a period
+///           FIRST_TO_HIT           — high vs low threshold race within a window
+///           RANGE_BUCKET           — close in [lowerBound, upperBound) — for neg-risk RANGE
+///           BEST_PERFORMER_OUTCOME — myFeed strictly beats peers' % change — for neg-risk BEST_PERFORMER
+contract CryptoCREOracle is IMarketOracle, CREReceiverBase {
+  // ─── Types ───────────────────────────────────────────────────────────
+
+  enum RuleType {
+    THRESHOLD,              // 0
+    DIRECTION,              // 1
+    CHANGE_PCT,             // 2
+    RELATIVE,               // 3
+    HIT,                    // 4
+    CANDLE,                 // 5 — param = candle interval in seconds
+    FIRST_TO_HIT,           // 6 — param = above threshold, paramB = below threshold, interval = sub-interval
+    RANGE_BUCKET,           // 7 — param = lowerBound, paramB = upperBound (half-open: [lower, upper)) on closePrice
+    BEST_PERFORMER_OUTCOME, // 8 — feedId = mine; peers stored separately; openTimestamp + closesAt define the period
+    RANGE_BUCKET_HIGH       // 9 — same as RANGE_BUCKET but on highPrice (for "highest milestone reached" outcomes)
+  }
+
+  /// @dev Per-market hint to the off-chain CRE workflow telling it which price
+  ///      source to query. The contract itself doesn't read prices from any
+  ///      source — it only stores prices the workflow delivered. This field
+  ///      makes the routing choice part of the on-chain market config so an
+  ///      off-chain admin can't silently flip it post-creation.
+  enum DataSource {
+    AUTO,             // 0 — workflow decides (Chainlink Feeds for non-OHLC where configured, Binance otherwise)
+    CHAINLINK_FEEDS,  // 1 — force Chainlink Data Feeds (on-chain Aggregator)
+    CHAINLINK_STREAMS,// 2 — force Chainlink Data Streams (off-chain HTTPS)
+    BINANCE           // 3 — force Binance klines REST API
+  }
+
+  /// @dev Per-market candle width for Binance kline reads. Only meaningful when
+  ///      the workflow's resolved data source is BINANCE; ignored otherwise.
+  ///      Mirrors the full set Binance's `/api/v3/klines` endpoint accepts
+  ///      (excluding `1s` which has limited endpoint coverage).
+  ///      Order is ascending by duration; values must not be reordered without
+  ///      a coordinated migration of any markets already initialized.
+  enum BinanceInterval {
+    ONE_MIN,      // 0  → "1m"
+    THREE_MIN,    // 1  → "3m"
+    FIVE_MIN,     // 2  → "5m"
+    FIFTEEN_MIN,  // 3  → "15m"
+    THIRTY_MIN,   // 4  → "30m"
+    ONE_HOUR,     // 5  → "1h"
+    TWO_HOUR,     // 6  → "2h"
+    FOUR_HOUR,    // 7  → "4h"
+    SIX_HOUR,     // 8  → "6h"
+    EIGHT_HOUR,   // 9  → "8h"
+    TWELVE_HOUR,  // 10 → "12h"
+    ONE_DAY,      // 11 → "1d"
+    THREE_DAY,    // 12 → "3d"
+    ONE_WEEK,     // 13 → "1w"
+    ONE_MONTH     // 14 → "1M"
+  }
+
+  struct MarketConfig {
+    bytes32 feedId;          // primary feed, e.g. keccak256("BTCUSDT")
+    bytes32 feedIdB;         // second feed for RELATIVE; 0x0 otherwise
+    RuleType rule;
+    bool yesAbove;           // flips direction — YES when condition met "above"
+    int256 param;            // price (THRESHOLD/HIT) or bps (CHANGE_PCT); 0 for DIRECTION/RELATIVE
+    uint256 closesAt;        // end timestamp (copied from manager)
+    uint256 openTimestamp;   // start timestamp; 0 for THRESHOLD
+    int256 paramB;           // FIRST_TO_HIT: below threshold; 0 otherwise
+    uint256 interval;        // FIRST_TO_HIT: sub-interval in seconds; 0 otherwise
+    bool initialized;
+    DataSource dataSource;          // workflow routing hint
+    BinanceInterval binanceInterval; // candle width when source resolves to BINANCE
+  }
+
+  struct PriceData {
+    int256 closePrice;       // price at this exact timestamp
+    int256 highPrice;        // highest price during the period ending at this timestamp
+    int256 lowPrice;         // lowest price during the period ending at this timestamp
+  }
+
+  // ─── State ───────────────────────────────────────────────────────────
+
+  address public immutable manager;
+
+  /// @dev Verified prices keyed by keccak256(abi.encode(feedId, timestamp)).
+  mapping(bytes32 => PriceData) public verifiedPrices;
+  mapping(bytes32 => bool) public priceExists;
+
+  mapping(uint256 => MarketConfig) public marketConfigs;
+
+  /// @dev BEST_PERFORMER_OUTCOME: per-market list of competing feed IDs.
+  ///      Each constituent in a neg-risk event stores everyone else's feed
+  ///      so it can compare its own % change against theirs.
+  mapping(uint256 => bytes32[]) internal marketPeerFeedIds;
+
+  // ─── Events ──────────────────────────────────────────────────────────
+
+  event PriceVerified(bytes32 indexed feedId, uint256 indexed timestamp, int256 closePrice, int256 highPrice, int256 lowPrice);
+  event MarketConfigured(uint256 indexed marketId, bytes32 feedId, RuleType rule, bool yesAbove, int256 param);
+
+  // ─── Constructor ─────────────────────────────────────────────────────
+
+  constructor(
+    AdminRegistry _registry,
+    address _manager,
+    address _keystoneForwarder
+  ) CREReceiverBase(_registry, _keystoneForwarder) {
+    require(_manager != address(0), "manager 0");
+    manager = _manager;
+  }
+
+  // ─── IMarketOracle: initialize ───────────────────────────────────────
+
+  /// @notice Called by the manager during createMarket().
+  ///
+  /// @param data Two encodings are accepted, distinguished by the third field
+  ///   (rule). Both formats start with `(bytes32 feedId, bytes32 feedIdB, uint8 rule)`
+  ///   so we peek at those three slots first.
+  ///
+  ///   Standard rules (rule ∈ 0..7, 9):
+  ///     abi.encode(bytes32 feedId, bytes32 feedIdB, uint8 rule, bool yesAbove,
+  ///                int256 param, uint256 openTimestamp, int256 paramB, uint256 interval,
+  ///                uint8 dataSource, uint8 binanceInterval)
+  ///
+  ///   BEST_PERFORMER_OUTCOME (rule == 8):
+  ///     abi.encode(bytes32 myFeedId, bytes32 unused, uint8 rule,
+  ///                bytes32[] peerFeedIds, uint256 openTimestamp,
+  ///                uint8 dataSource, uint8 binanceInterval)
+  function initialize(uint256 marketId, bytes calldata data) external override {
+    require(msg.sender == manager, "!manager");
+    require(!marketConfigs[marketId].initialized, "already init");
+
+    (bytes32 feedId, , uint8 ruleRaw) = abi.decode(data[:96], (bytes32, bytes32, uint8));
+    require(feedId != bytes32(0), "feedId 0");
+    require(ruleRaw <= uint8(type(RuleType).max), "invalid rule");
+    RuleType rule = RuleType(ruleRaw);
+
+    if (rule == RuleType.BEST_PERFORMER_OUTCOME) {
+      _initBestPerformerOutcome(marketId, data);
+    } else {
+      _initStandard(marketId, data);
+    }
+  }
+
+  function _initStandard(uint256 marketId, bytes calldata data) internal {
+    (
+      bytes32 feedId,
+      bytes32 feedIdB,
+      uint8 ruleRaw,
+      bool yesAbove,
+      int256 param,
+      uint256 openTimestamp,
+      int256 paramB,
+      uint256 interval,
+      uint8 dataSourceRaw,
+      uint8 binanceIntervalRaw
+    ) = abi.decode(data, (bytes32, bytes32, uint8, bool, int256, uint256, int256, uint256, uint8, uint8));
+
+    RuleType rule = RuleType(ruleRaw);
+    require(dataSourceRaw <= uint8(type(DataSource).max), "invalid dataSource");
+    require(binanceIntervalRaw <= uint8(type(BinanceInterval).max), "invalid binanceInterval");
+    DataSource dataSource = DataSource(dataSourceRaw);
+
+    // OHLC-only rules can't be served by either Chainlink path.
+    if (rule == RuleType.HIT || rule == RuleType.CANDLE || rule == RuleType.FIRST_TO_HIT || rule == RuleType.RANGE_BUCKET_HIGH) {
+      require(
+        dataSource == DataSource.AUTO || dataSource == DataSource.BINANCE,
+        "OHLC rule needs binance/auto"
+      );
+    }
+
+    // Validate rule-specific constraints
+    if (rule == RuleType.RELATIVE) {
+      require(feedIdB != bytes32(0), "feedIdB required for RELATIVE");
+    }
+    if (rule == RuleType.DIRECTION || rule == RuleType.CHANGE_PCT || rule == RuleType.RELATIVE || rule == RuleType.CANDLE || rule == RuleType.FIRST_TO_HIT) {
+      require(openTimestamp > 0, "openTimestamp required");
+    }
+    if (rule == RuleType.THRESHOLD || rule == RuleType.HIT) {
+      require(param != 0, "param required");
+    }
+    if (rule == RuleType.CANDLE) {
+      require(param > 0, "candle interval required");
+    }
+    if (rule == RuleType.FIRST_TO_HIT) {
+      require(param != 0, "above threshold required");
+      require(paramB != 0, "below threshold required");
+      require(interval > 0, "interval required");
+    }
+    if (rule == RuleType.RANGE_BUCKET || rule == RuleType.RANGE_BUCKET_HIGH) {
+      require(paramB > param, "upperBound > lowerBound");
+    }
+
+    uint256 closesAt = ICREOracleManagerView(manager).getMarketClosesAt(marketId);
+
+    marketConfigs[marketId] = MarketConfig({
+      feedId: feedId,
+      feedIdB: feedIdB,
+      rule: rule,
+      yesAbove: yesAbove,
+      param: param,
+      closesAt: closesAt,
+      openTimestamp: openTimestamp,
+      paramB: paramB,
+      interval: interval,
+      initialized: true,
+      dataSource: dataSource,
+      binanceInterval: BinanceInterval(binanceIntervalRaw)
+    });
+
+    emit MarketConfigured(marketId, feedId, rule, yesAbove, param);
+  }
+
+  function _initBestPerformerOutcome(uint256 marketId, bytes calldata data) internal {
+    (
+      bytes32 myFeedId,
+      ,
+      uint8 ruleRaw,
+      bytes32[] memory peerFeedIds,
+      uint256 openTimestamp,
+      uint8 dataSourceRaw,
+      uint8 binanceIntervalRaw
+    ) = abi.decode(data, (bytes32, bytes32, uint8, bytes32[], uint256, uint8, uint8));
+
+    require(peerFeedIds.length > 0, "no peers");
+    require(openTimestamp > 0, "openTimestamp required");
+    require(dataSourceRaw <= uint8(type(DataSource).max), "invalid dataSource");
+    require(binanceIntervalRaw <= uint8(type(BinanceInterval).max), "invalid binanceInterval");
+    for (uint256 i = 0; i < peerFeedIds.length; i++) {
+      require(peerFeedIds[i] != bytes32(0), "peer feedId 0");
+      require(peerFeedIds[i] != myFeedId, "peer = self");
+    }
+
+    uint256 closesAt = ICREOracleManagerView(manager).getMarketClosesAt(marketId);
+
+    marketConfigs[marketId] = MarketConfig({
+      feedId: myFeedId,
+      feedIdB: bytes32(0),
+      rule: RuleType(ruleRaw),
+      yesAbove: true,
+      param: 0,
+      closesAt: closesAt,
+      openTimestamp: openTimestamp,
+      paramB: 0,
+      interval: 0,
+      initialized: true,
+      dataSource: DataSource(dataSourceRaw),
+      binanceInterval: BinanceInterval(binanceIntervalRaw)
+    });
+
+    bytes32[] storage peers = marketPeerFeedIds[marketId];
+    for (uint256 i = 0; i < peerFeedIds.length; i++) {
+      peers.push(peerFeedIds[i]);
+    }
+
+    emit MarketConfigured(marketId, myFeedId, RuleType(ruleRaw), true, 0);
+  }
+
+  // ─── ICREReceiver: onReport ──────────────────────────────────────────
+
+  /// @notice Receives verified price data from the Chainlink CRE workflow.
+  /// @param metadata Workflow metadata (contains workflow ID, name, owner).
+  /// @param report ABI-encoded (bytes32[] feedIds, uint256[] timestamps, int256[] closePrices, int256[] highPrices, int256[] lowPrices).
+  function onReport(bytes calldata metadata, bytes calldata report) external override {
+    _validate(metadata);
+
+    // Decode report
+    (
+      bytes32[] memory feedIds,
+      uint256[] memory timestamps,
+      int256[] memory closePrices,
+      int256[] memory highPrices,
+      int256[] memory lowPrices
+    ) = abi.decode(report, (bytes32[], uint256[], int256[], int256[], int256[]));
+
+    uint256 len = feedIds.length;
+    require(
+      timestamps.length == len && closePrices.length == len && highPrices.length == len && lowPrices.length == len,
+      "length mismatch"
+    );
+
+    for (uint256 i = 0; i < len; i++) {
+      bytes32 priceKey = keccak256(abi.encode(feedIds[i], timestamps[i]));
+
+      // Write-once: skip if already stored
+      if (!priceExists[priceKey]) {
+        verifiedPrices[priceKey] = PriceData({
+          closePrice: closePrices[i],
+          highPrice: highPrices[i],
+          lowPrice: lowPrices[i]
+        });
+        priceExists[priceKey] = true;
+
+        emit PriceVerified(feedIds[i], timestamps[i], closePrices[i], highPrices[i], lowPrices[i]);
+      }
+    }
+  }
+
+  // ─── IMarketOracle: getResult ────────────────────────────────────────
+
+  /// @notice Computes the binary outcome for a market from stored verified prices.
+  /// @return outcome 0 (YES), 1 (NO), or -1 (VOIDED).
+  /// @return resolved true if all required prices are available and outcome is computed.
+  function getResult(uint256 marketId) external view override returns (int256 outcome, bool resolved) {
+    MarketConfig storage config = marketConfigs[marketId];
+    require(config.initialized, "!init");
+
+    if (config.rule == RuleType.THRESHOLD) {
+      return _resolveThreshold(config);
+    } else if (config.rule == RuleType.DIRECTION) {
+      return _resolveDirection(config);
+    } else if (config.rule == RuleType.CHANGE_PCT) {
+      return _resolveChangePct(config);
+    } else if (config.rule == RuleType.RELATIVE) {
+      return _resolveRelative(config);
+    } else if (config.rule == RuleType.HIT) {
+      return _resolveHit(config);
+    } else if (config.rule == RuleType.CANDLE) {
+      return _resolveCandle(config);
+    } else if (config.rule == RuleType.FIRST_TO_HIT) {
+      return _resolveFirstToHit(config);
+    } else if (config.rule == RuleType.RANGE_BUCKET) {
+      return _resolveRangeBucket(config, false);
+    } else if (config.rule == RuleType.BEST_PERFORMER_OUTCOME) {
+      return _resolveBestPerformerOutcome(config, marketId);
+    } else if (config.rule == RuleType.RANGE_BUCKET_HIGH) {
+      return _resolveRangeBucket(config, true);
+    }
+
+    return (Outcomes.VOIDED, true);
+  }
+
+  // ─── Internal resolution logic ───────────────────────────────────────
+
+  function _resolveThreshold(MarketConfig storage config) internal view returns (int256, bool) {
+    (int256 closePrice, bool ok) = _getClosePrice(config.feedId, config.closesAt);
+    if (!ok) return (-2, false);
+
+    bool condition = closePrice >= config.param;
+    return _outcomeFromCondition(condition, config.yesAbove);
+  }
+
+  function _resolveDirection(MarketConfig storage config) internal view returns (int256, bool) {
+    (int256 openPrice, bool okOpen) = _getClosePrice(config.feedId, config.openTimestamp);
+    if (!okOpen) return (-2, false);
+
+    (int256 closePrice, bool okClose) = _getClosePrice(config.feedId, config.closesAt);
+    if (!okClose) return (-2, false);
+
+    // Tie → NO regardless of yesAbove
+    if (closePrice == openPrice) return (int256(Outcomes.NO), true);
+
+    bool condition = closePrice > openPrice;
+    return _outcomeFromCondition(condition, config.yesAbove);
+  }
+
+  function _resolveChangePct(MarketConfig storage config) internal view returns (int256, bool) {
+    (int256 openPrice, bool okOpen) = _getClosePrice(config.feedId, config.openTimestamp);
+    if (!okOpen) return (-2, false);
+
+    (int256 closePrice, bool okClose) = _getClosePrice(config.feedId, config.closesAt);
+    if (!okClose) return (-2, false);
+
+    // Avoid division by zero
+    if (openPrice == 0) return (Outcomes.VOIDED, true);
+
+    // Calculate |% change| in bps: |close - open| * 10000 / |open|
+    int256 diff = closePrice - openPrice;
+    if (diff < 0) diff = -diff;
+    int256 absOpen = openPrice < 0 ? -openPrice : openPrice;
+    int256 changeBps = (diff * 10000) / absOpen;
+
+    bool condition = changeBps >= config.param;
+    return _outcomeFromCondition(condition, config.yesAbove);
+  }
+
+  function _resolveRelative(MarketConfig storage config) internal view returns (int256, bool) {
+    // Feed A: primary
+    (int256 openA, bool okOpenA) = _getClosePrice(config.feedId, config.openTimestamp);
+    if (!okOpenA) return (-2, false);
+    (int256 closeA, bool okCloseA) = _getClosePrice(config.feedId, config.closesAt);
+    if (!okCloseA) return (-2, false);
+
+    // Feed B: secondary
+    (int256 openB, bool okOpenB) = _getClosePrice(config.feedIdB, config.openTimestamp);
+    if (!okOpenB) return (-2, false);
+    (int256 closeB, bool okCloseB) = _getClosePrice(config.feedIdB, config.closesAt);
+    if (!okCloseB) return (-2, false);
+
+    if (openA == 0 || openB == 0) return (Outcomes.VOIDED, true);
+
+    // Compare % changes using cross-multiplication to avoid precision loss:
+    // changeA% > changeB%  ⟺  (closeA - openA) / openA > (closeB - openB) / openB
+    // ⟺  (closeA - openA) * openB > (closeB - openB) * openA  (when openA, openB > 0)
+    // For negative prices (shouldn't happen but be safe), we use the sign-aware form.
+    int256 lhs = (closeA - openA) * openB;
+    int256 rhs = (closeB - openB) * openA;
+
+    // Tie → NO
+    if (lhs == rhs) return (int256(Outcomes.NO), true);
+
+    bool condition = lhs > rhs;
+    return _outcomeFromCondition(condition, config.yesAbove);
+  }
+
+  function _resolveHit(MarketConfig storage config) internal view returns (int256, bool) {
+    bytes32 priceKey = keccak256(abi.encode(config.feedId, config.closesAt));
+    if (!priceExists[priceKey]) return (-2, false);
+
+    PriceData storage pd = verifiedPrices[priceKey];
+
+    bool condition;
+    if (config.yesAbove) {
+      // "Will price hit X?" — did the high reach param?
+      condition = pd.highPrice >= config.param;
+    } else {
+      // "Will price dip below X?" — did the low drop to param?
+      condition = pd.lowPrice <= config.param;
+    }
+
+    return _outcomeFromCondition(condition, true); // condition already accounts for yesAbove
+  }
+
+  function _resolveCandle(MarketConfig storage config) internal view returns (int256, bool) {
+    uint256 interval = uint256(config.param);
+    uint256 start = config.openTimestamp;
+    uint256 end = config.closesAt;
+
+    uint256 greenCount = 0;
+    uint256 redCount = 0;
+
+    for (uint256 t = start; t + interval <= end; t += interval) {
+      (int256 candleOpen, bool okOpen) = _getClosePrice(config.feedId, t);
+      if (!okOpen) return (-2, false);
+      (int256 candleClose, bool okClose) = _getClosePrice(config.feedId, t + interval);
+      if (!okClose) return (-2, false);
+
+      if (candleClose > candleOpen) {
+        greenCount++;
+      } else if (candleClose < candleOpen) {
+        redCount++;
+      }
+      // flat candle (close == open) counts as neither
+    }
+
+    // Tie (green == red) → NO
+    if (greenCount == redCount) return (int256(Outcomes.NO), true);
+
+    bool condition = greenCount > redCount;
+    return _outcomeFromCondition(condition, config.yesAbove);
+  }
+
+  function _resolveRangeBucket(MarketConfig storage config, bool useHigh) internal view returns (int256, bool) {
+    bytes32 priceKey = keccak256(abi.encode(config.feedId, config.closesAt));
+    if (!priceExists[priceKey]) return (-2, false);
+
+    PriceData storage pd = verifiedPrices[priceKey];
+    int256 price = useHigh ? pd.highPrice : pd.closePrice;
+
+    bool inRange = price >= config.param && price < config.paramB;
+    return inRange ? (int256(Outcomes.YES), true) : (int256(Outcomes.NO), true);
+  }
+
+  function _resolveBestPerformerOutcome(MarketConfig storage config, uint256 marketId)
+    internal
+    view
+    returns (int256, bool)
+  {
+    (int256 myOpen, bool okMyOpen) = _getClosePrice(config.feedId, config.openTimestamp);
+    if (!okMyOpen) return (-2, false);
+    (int256 myClose, bool okMyClose) = _getClosePrice(config.feedId, config.closesAt);
+    if (!okMyClose) return (-2, false);
+
+    // If my open is 0 we can't compute a meaningful % change → can't win.
+    if (myOpen == 0) return (int256(Outcomes.NO), true);
+
+    int256 myAbsOpen = myOpen < 0 ? -myOpen : myOpen;
+    int256 myChange = ((myClose - myOpen) * 10000) / myAbsOpen;
+
+    bytes32[] storage peers = marketPeerFeedIds[marketId];
+    uint256 n = peers.length;
+    for (uint256 i = 0; i < n; i++) {
+      (int256 peerOpen, bool okPeerOpen) = _getClosePrice(peers[i], config.openTimestamp);
+      if (!okPeerOpen) return (-2, false);
+      (int256 peerClose, bool okPeerClose) = _getClosePrice(peers[i], config.closesAt);
+      if (!okPeerClose) return (-2, false);
+
+      // Skip peers with a zero open price — they have no comparable %change.
+      if (peerOpen == 0) continue;
+
+      int256 peerAbsOpen = peerOpen < 0 ? -peerOpen : peerOpen;
+      int256 peerChange = ((peerClose - peerOpen) * 10000) / peerAbsOpen;
+
+      // Strictly greater than every peer to win. Tie at top → NO.
+      if (peerChange >= myChange) return (int256(Outcomes.NO), true);
+    }
+
+    return (int256(Outcomes.YES), true);
+  }
+
+  function _resolveFirstToHit(MarketConfig storage config) internal view returns (int256, bool) {
+    uint256 start = config.openTimestamp;
+    uint256 end = config.closesAt;
+    uint256 step = config.interval;
+
+    for (uint256 t = start; t + step <= end; t += step) {
+      bytes32 priceKey = keccak256(abi.encode(config.feedId, t + step));
+      if (!priceExists[priceKey]) return (-2, false);
+
+      PriceData storage pd = verifiedPrices[priceKey];
+      bool aboveHit = pd.highPrice >= config.param;
+      bool belowHit = pd.lowPrice <= config.paramB;
+
+      if (aboveHit && !belowHit) {
+        // Above threshold hit first in this interval
+        return _outcomeFromCondition(true, config.yesAbove);
+      }
+      if (belowHit && !aboveHit) {
+        // Below threshold hit first in this interval
+        return _outcomeFromCondition(false, config.yesAbove);
+      }
+      // Both hit in same interval → inconclusive, check next (finer) interval
+      // Neither hit → continue
+    }
+
+    // Exhausted all intervals with no clear winner → not resolved
+    return (-2, false);
+  }
+
+  // ─── Helpers ─────────────────────────────────────────────────────────
+
+  function _getClosePrice(bytes32 feedId, uint256 timestamp) internal view returns (int256, bool) {
+    bytes32 priceKey = keccak256(abi.encode(feedId, timestamp));
+    if (!priceExists[priceKey]) return (0, false);
+    return (verifiedPrices[priceKey].closePrice, true);
+  }
+
+  /// @dev Maps a boolean condition to YES/NO based on yesAbove.
+  function _outcomeFromCondition(bool condition, bool yesAbove) internal pure returns (int256, bool) {
+    if (condition == yesAbove) {
+      return (int256(Outcomes.YES), true);
+    } else {
+      return (int256(Outcomes.NO), true);
+    }
+  }
+
+  // ─── View helpers ────────────────────────────────────────────────────
+
+  /// @notice Returns the peer feed IDs configured for a BEST_PERFORMER_OUTCOME market.
+  function getMarketPeerFeedIds(uint256 marketId) external view returns (bytes32[] memory) {
+    return marketPeerFeedIds[marketId];
+  }
+
+  /// @notice Returns verified price data for a (feedId, timestamp) pair.
+  function getVerifiedPrice(bytes32 feedId, uint256 timestamp)
+    external
+    view
+    returns (int256 closePrice, int256 highPrice, int256 lowPrice, bool exists)
+  {
+    bytes32 priceKey = keccak256(abi.encode(feedId, timestamp));
+    if (!priceExists[priceKey]) return (0, 0, 0, false);
+    PriceData storage pd = verifiedPrices[priceKey];
+    return (pd.closePrice, pd.highPrice, pd.lowPrice, true);
+  }
+}

--- a/contracts/oracles/ICREReceiver.sol
+++ b/contracts/oracles/ICREReceiver.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+/// @title ICREReceiver
+/// @notice Chainlink CRE IReceiver interface (must extend ERC165).
+///         Contracts implementing this interface can receive verified reports
+///         from the Chainlink KeystoneForwarder.
+/// @dev The forwarder verifies ERC165 support for type(ICREReceiver).interfaceId
+///      before calling onReport. Implementers MUST return true for it.
+interface ICREReceiver is IERC165 {
+  /// @notice Called by the KeystoneForwarder to deliver a verified workflow report.
+  /// @param metadata Packed metadata (64 bytes): workflowId(32) + workflowName(10) + workflowOwner(20).
+  /// @param report ABI-encoded report payload.
+  function onReport(bytes calldata metadata, bytes calldata report) external;
+}

--- a/contracts/oracles/SportsCREOracle.sol
+++ b/contracts/oracles/SportsCREOracle.sol
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import "../IMarketOracle.sol";
+import "../Outcomes.sol";
+import {CREReceiverBase} from "./CREReceiverBase.sol";
+import {AdminRegistry} from "../AdminRegistry.sol";
+
+interface ISportsManagerView {
+  function getMarketClosesAt(uint256 marketId) external view returns (uint256);
+}
+
+/// @title SportsCREOracle
+/// @notice IMarketOracle + ICREReceiver implementation for sports markets.
+///         Generic result store — the CRE workflow resolves off-chain via OddsPapi
+///         (inside DON consensus + TEE) and delivers the winning outcome per market.
+///         The contract has no sport-specific logic: any market type (match winner,
+///         totals, spread, player props, parlay, ...) is handled by the workflow.
+///
+///         Trust model: DON consensus over OddsPapi HTTP response + write-once storage.
+///         This is "Option A" (off-chain calculation) applied to sports because the
+///         data source and resolution logic are inherently off-chain.
+contract SportsCREOracle is IMarketOracle, CREReceiverBase {
+  // ─── Types ───────────────────────────────────────────────────────────
+
+  struct MarketConfig {
+    string externalRef;      // e.g. "oddspapi:id1100013262926181:1:2"
+                             // parseable by CRE workflow
+    uint256 closesAt;        // end timestamp (copied from manager)
+    bool initialized;
+  }
+
+  // ─── State ───────────────────────────────────────────────────────────
+
+  address public immutable manager;
+
+  /// @dev Resolved outcomes keyed by keccak256(externalRef).
+  ///      Shared across markets with the same externalRef (rare but possible).
+  mapping(bytes32 => int256) public resolvedOutcomes;
+  mapping(bytes32 => bool) public outcomeResolved;
+
+  mapping(uint256 => MarketConfig) public marketConfigs;
+
+  // ─── Events ──────────────────────────────────────────────────────────
+
+  event SportsResultReported(bytes32 indexed externalRefHash, int256 outcomeId);
+  event MarketConfigured(uint256 indexed marketId, string externalRef);
+
+  // ─── Constructor ─────────────────────────────────────────────────────
+
+  constructor(
+    AdminRegistry _registry,
+    address _manager,
+    address _keystoneForwarder
+  ) CREReceiverBase(_registry, _keystoneForwarder) {
+    require(_manager != address(0), "manager 0");
+    manager = _manager;
+  }
+
+  // ─── IMarketOracle: initialize ───────────────────────────────────────
+
+  /// @notice Called by the manager during createMarket().
+  /// @param data ABI-encoded (string externalRef)
+  function initialize(uint256 marketId, bytes calldata data) external override {
+    require(msg.sender == manager, "!manager");
+    require(!marketConfigs[marketId].initialized, "already init");
+
+    (string memory externalRef) = abi.decode(data, (string));
+    require(bytes(externalRef).length > 0, "externalRef required");
+
+    uint256 closesAt = ISportsManagerView(manager).getMarketClosesAt(marketId);
+
+    marketConfigs[marketId] = MarketConfig({
+      externalRef: externalRef,
+      closesAt: closesAt,
+      initialized: true
+    });
+
+    emit MarketConfigured(marketId, externalRef);
+  }
+
+  // ─── ICREReceiver: onReport ──────────────────────────────────────────
+
+  /// @notice Receives resolved sports outcomes from the CRE workflow.
+  /// @param metadata Workflow metadata (validated for workflow identity).
+  /// @param report ABI-encoded (string[] externalRefs, int256[] outcomeIds).
+  ///        outcomeId: 0 = YES, 1 = NO, -1 = VOIDED (fixture cancelled/postponed)
+  function onReport(bytes calldata metadata, bytes calldata report) external override {
+    _validate(metadata);
+
+    (string[] memory externalRefs, int256[] memory outcomeIds) =
+      abi.decode(report, (string[], int256[]));
+
+    uint256 len = externalRefs.length;
+    require(outcomeIds.length == len, "length mismatch");
+
+    for (uint256 i = 0; i < len; i++) {
+      bytes32 refHash = keccak256(bytes(externalRefs[i]));
+
+      // Write-once: skip if already resolved
+      if (!outcomeResolved[refHash]) {
+        int256 outcomeId = outcomeIds[i];
+        require(
+          outcomeId == int256(Outcomes.YES) ||
+          outcomeId == int256(Outcomes.NO) ||
+          outcomeId == Outcomes.VOIDED,
+          "invalid outcomeId"
+        );
+
+        resolvedOutcomes[refHash] = outcomeId;
+        outcomeResolved[refHash] = true;
+
+        emit SportsResultReported(refHash, outcomeId);
+      }
+    }
+  }
+
+  // ─── IMarketOracle: getResult ────────────────────────────────────────
+
+  /// @notice Returns the resolved outcome for a market.
+  /// @return outcome 0 (YES), 1 (NO), or -1 (VOIDED).
+  /// @return resolved true if the CRE workflow has reported the outcome.
+  function getResult(uint256 marketId) external view override returns (int256 outcome, bool resolved) {
+    MarketConfig storage config = marketConfigs[marketId];
+    require(config.initialized, "!init");
+
+    bytes32 refHash = keccak256(bytes(config.externalRef));
+    if (!outcomeResolved[refHash]) {
+      return (-2, false);
+    }
+
+    return (resolvedOutcomes[refHash], true);
+  }
+
+  // ─── View helpers ────────────────────────────────────────────────────
+
+  /// @notice Returns the externalRef and its hash for a market.
+  function getMarketExternalRef(uint256 marketId) external view returns (string memory ref, bytes32 refHash) {
+    MarketConfig storage config = marketConfigs[marketId];
+    require(config.initialized, "!init");
+    ref = config.externalRef;
+    refHash = keccak256(bytes(config.externalRef));
+  }
+
+}

--- a/script/CreateCLOBMarket.s.sol
+++ b/script/CreateCLOBMarket.s.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.26;
 import {Script, console} from "forge-std/Script.sol";
 import {PredictionMarketV3ManagerCLOB} from "../contracts/PredictionMarketV3ManagerCLOB.sol";
 
-/// @notice Creates a CLOB market with an optional Realitio oracle.
+/// @notice Creates a CLOB market with an optional oracle (Realitio or CRE).
 ///
 ///         Signing: use an encrypted keystore account, never a plaintext key —
 ///           cast wallet import <name> --interactive   # one-time
@@ -20,11 +20,22 @@ import {PredictionMarketV3ManagerCLOB} from "../contracts/PredictionMarketV3Mana
 ///         Env vars (optional):
 ///           IMAGE          — IPFS hash or URL (default: "")
 ///           ORACLE         — oracle contract address (default: address(0) = no oracle)
-///           ORACLE_TYPE    — "realitio" or "none" (default: "none")
+///           ORACLE_TYPE    — "realitio", "cre", or "none" (default: "none")
 ///
 ///         Realitio-specific env vars:
 ///           ARBITRATOR       — Reality.eth arbitrator address
 ///           REALITIO_TIMEOUT — timeout in seconds (default: 3600)
+///
+///         CRE-specific env vars:
+///           FEED_ID          — price feed pair (e.g. "BTCUSDT")
+///           FEED_ID_B        — second feed for RELATIVE rule (default: "")
+///           RULE_TYPE        — 0=THRESHOLD, 1=DIRECTION, 2=CHANGE_PCT, 3=RELATIVE, 4=HIT
+///           YES_ABOVE        — "true" or "false"
+///           PARAM            — price (THRESHOLD/HIT) or bps (CHANGE_PCT), 0 otherwise
+///           OPEN_TIMESTAMP   — start timestamp for DIRECTION/CHANGE_PCT/RELATIVE (default: 0)
+///           DATA_SOURCE      — 0=AUTO, 1=CHAINLINK_FEEDS, 2=CHAINLINK_STREAMS, 3=BINANCE (default: 0)
+///           BINANCE_INTERVAL — 0=1m, 1=3m, 2=5m, 3=15m, 4=30m, 5=1h, 6=2h, 7=4h, 8=6h,
+///                              9=8h, 10=12h, 11=1d, 12=3d, 13=1w, 14=1M (default: 0)
 contract CreateCLOBMarket is Script {
   function run() external {
     address managerAddr = vm.envAddress("CLOB_MANAGER");
@@ -42,6 +53,24 @@ contract CreateCLOBMarket is Script {
       address arbitrator = vm.envAddress("ARBITRATOR");
       uint32 timeout = uint32(vm.envOr("REALITIO_TIMEOUT", uint256(3600)));
       oracleData = abi.encode(question, arbitrator, timeout, uint32(closesAt));
+    } else if (keccak256(bytes(oracleType)) == keccak256(bytes("cre"))) {
+      string memory feedIdStr = vm.envString("FEED_ID");
+      string memory feedIdBStr = vm.envOr("FEED_ID_B", string(""));
+      uint8 ruleType = uint8(vm.envUint("RULE_TYPE"));
+      bool yesAbove = vm.envBool("YES_ABOVE");
+      int256 param = vm.envOr("PARAM", int256(0));
+      uint256 openTimestamp = vm.envOr("OPEN_TIMESTAMP", uint256(0));
+      int256 paramB = vm.envOr("PARAM_B", int256(0));
+      uint256 interval = vm.envOr("INTERVAL", uint256(0));
+      uint8 dataSource = uint8(vm.envOr("DATA_SOURCE", uint256(0)));
+      uint8 binanceInterval = uint8(vm.envOr("BINANCE_INTERVAL", uint256(0)));
+
+      bytes32 feedId = keccak256(bytes(feedIdStr));
+      bytes32 feedIdB = bytes(feedIdBStr).length > 0 ? keccak256(bytes(feedIdBStr)) : bytes32(0);
+
+      oracleData = abi.encode(
+        feedId, feedIdB, ruleType, yesAbove, param, openTimestamp, paramB, interval, dataSource, binanceInterval
+      );
     }
 
     // Signer comes from the --account keystore; no private key in env.

--- a/script/CreateNegRiskEvent.s.sol
+++ b/script/CreateNegRiskEvent.s.sol
@@ -7,23 +7,57 @@ import {NegRiskAdapter} from "../contracts/NegRiskAdapter.sol";
 import {PredictionMarketV3ManagerCLOB} from "../contracts/PredictionMarketV3ManagerCLOB.sol";
 
 /// @notice Creates a neg-risk event with all named outcomes via the NegRiskAdapter.
+///         Each constituent market carries per-market oracle config encoded in
+///         `oracleData` so it resolves independently — see `EVENT_RULE_TYPE` modes.
 ///
 ///         Signing: use an encrypted keystore account, never a plaintext key —
 ///           cast wallet import <name> --interactive   # one-time
 ///           forge script ... --account <name> --sender <addr>
 ///         The signer must have MARKET_ADMIN_ROLE.
 ///
-///         Env vars (required):
+///         Common env vars (required):
 ///           NEG_RISK_ADAPTER     — NegRiskAdapter address
 ///           CLOB_FEE_MODULE      — FeeModule address (used per-market)
 ///           CLOSES_AT            — unix timestamp when all outcome markets close
 ///           OUTCOMES             — comma-separated outcome names (e.g. "Trump,Harris,Biden")
 ///           QUESTION             — parent event question
 ///
-///         Env vars (optional):
+///         Common env vars (optional):
 ///           IMAGE                — IPFS hash or URL (default: "")
 ///           ORACLE               — oracle contract address (default: address(0))
+///           EVENT_RULE_TYPE      — 0=NONE (uniform empty oracleData),
+///                                  1=RANGE       (CryptoCREOracle, RANGE_BUCKET on close),
+///                                  2=HIT_MILESTONES (CryptoCREOracle, RANGE_BUCKET_HIGH on high),
+///                                  3=BEST_PERFORMER (CryptoCREOracle, BEST_PERFORMER_OUTCOME)
+///                                  default: 0
+///
+///         RANGE / HIT_MILESTONES env vars:
+///           FEED_ID              — feed pair name (e.g. "BTCUSDT")
+///           BOUNDARIES           — N-1 sorted ascending int256 boundaries
+///                                  (8-decimal fixed point), comma-separated
+///                                  Defines N buckets:
+///                                    bucket 0 : [int256.min, b0)
+///                                    bucket i : [b_{i-1}, b_i)   (1 <= i <= N-2)
+///                                    bucket N-1: [b_{N-2}, int256.max)
+///
+///         BEST_PERFORMER env vars:
+///           FEED_IDS             — comma-separated feed pair names, one per outcome
+///                                  (e.g. "BTCUSDT,ETHUSDT,SOLUSDT,DOGEUSDT")
+///           OPEN_TIMESTAMP       — unix timestamp at which open prices are sampled
 contract CreateNegRiskEvent is Script {
+  // CryptoCREOracle.RuleType values (kept here as constants to avoid the
+  // dependency on the oracle's own enum for callers that compile alone)
+  uint8 internal constant RULE_HIT = 4;
+  uint8 internal constant RULE_RANGE_BUCKET = 7;
+  uint8 internal constant RULE_BEST_PERFORMER_OUTCOME = 8;
+  uint8 internal constant RULE_RANGE_BUCKET_HIGH = 9;
+
+  // EVENT_RULE_TYPE values
+  uint8 internal constant EVENT_NONE = 0;
+  uint8 internal constant EVENT_RANGE = 1;
+  uint8 internal constant EVENT_HIT_MILESTONES = 2;
+  uint8 internal constant EVENT_BEST_PERFORMER = 3;
+
   function run() external {
     address adapterAddr = vm.envAddress("NEG_RISK_ADAPTER");
     address feeModule = vm.envAddress("CLOB_FEE_MODULE");
@@ -32,9 +66,12 @@ contract CreateNegRiskEvent is Script {
     string memory eventQuestion = vm.envString("QUESTION");
     string memory image = vm.envOr("IMAGE", string(""));
     address oracle = vm.envOr("ORACLE", address(0));
+    uint8 eventRuleType = uint8(vm.envOr("EVENT_RULE_TYPE", uint256(EVENT_NONE)));
 
     string[] memory outcomes = _split(outcomesRaw, ",");
     require(outcomes.length >= 2, "need >= 2 outcomes");
+
+    bytes[] memory perMarketOracleData = _buildOracleData(eventRuleType, outcomes.length);
 
     PredictionMarketV3ManagerCLOB.CreateMarketParams[] memory params =
       new PredictionMarketV3ManagerCLOB.CreateMarketParams[](outcomes.length);
@@ -45,7 +82,7 @@ contract CreateNegRiskEvent is Script {
         image: image,
         feeModule: feeModule,
         oracle: oracle,
-        oracleData: ""
+        oracleData: perMarketOracleData[i]
       });
     }
 
@@ -57,9 +94,93 @@ contract CreateNegRiskEvent is Script {
     console.log("Event created:");
     console.logBytes32(eventId);
     console.log("Outcomes:", outcomes.length);
+    console.log("Event rule type:", eventRuleType);
     for (uint256 i = 0; i < outcomes.length; i++) {
       console.log("  Outcome", i, ":", outcomes[i]);
     }
+  }
+
+  function _buildOracleData(uint8 eventRuleType, uint256 n)
+    internal
+    view
+    returns (bytes[] memory data)
+  {
+    data = new bytes[](n);
+
+    if (eventRuleType == EVENT_NONE) {
+      for (uint256 i = 0; i < n; i++) data[i] = "";
+      return data;
+    }
+
+    if (eventRuleType == EVENT_RANGE || eventRuleType == EVENT_HIT_MILESTONES) {
+      string memory feedIdRaw = vm.envString("FEED_ID");
+      bytes32 feedId = keccak256(bytes(feedIdRaw));
+
+      string memory boundariesRaw = vm.envString("BOUNDARIES");
+      string[] memory boundaryStrs = _split(boundariesRaw, ",");
+      require(boundaryStrs.length == n - 1, "BOUNDARIES count must equal outcomes-1");
+
+      int256[] memory boundaries = new int256[](n - 1);
+      for (uint256 i = 0; i < n - 1; i++) {
+        boundaries[i] = vm.parseInt(boundaryStrs[i]);
+        if (i > 0) {
+          require(boundaries[i] > boundaries[i - 1], "boundaries not ascending");
+        }
+      }
+
+      uint8 rule = eventRuleType == EVENT_RANGE ? RULE_RANGE_BUCKET : RULE_RANGE_BUCKET_HIGH;
+
+      for (uint256 i = 0; i < n; i++) {
+        int256 lower = i == 0 ? type(int256).min : boundaries[i - 1];
+        int256 upper = i == n - 1 ? type(int256).max : boundaries[i];
+        data[i] = abi.encode(
+          feedId,         // feedId
+          bytes32(0),     // feedIdB
+          rule,           // ruleRaw
+          true,           // yesAbove (unused by RANGE_BUCKET*; harmless)
+          lower,          // param = lowerBound
+          uint256(0),     // openTimestamp (unused for RANGE_BUCKET*)
+          upper,          // paramB = upperBound
+          uint256(0),     // interval (unused)
+          uint8(0),       // dataSourceRaw (AUTO)
+          uint8(0)        // binanceIntervalRaw (1m)
+        );
+      }
+      return data;
+    }
+
+    if (eventRuleType == EVENT_BEST_PERFORMER) {
+      string memory feedIdsRaw = vm.envString("FEED_IDS");
+      uint256 openTimestamp = vm.envUint("OPEN_TIMESTAMP");
+      require(openTimestamp > 0, "OPEN_TIMESTAMP required");
+
+      string[] memory feedNames = _split(feedIdsRaw, ",");
+      require(feedNames.length == n, "FEED_IDS count must equal outcomes");
+
+      bytes32[] memory feedIds = new bytes32[](n);
+      for (uint256 i = 0; i < n; i++) feedIds[i] = keccak256(bytes(feedNames[i]));
+
+      for (uint256 i = 0; i < n; i++) {
+        bytes32[] memory peers = new bytes32[](n - 1);
+        uint256 p;
+        for (uint256 j = 0; j < n; j++) {
+          if (j == i) continue;
+          peers[p++] = feedIds[j];
+        }
+        data[i] = abi.encode(
+          feedIds[i],            // myFeedId
+          bytes32(0),            // unused
+          RULE_BEST_PERFORMER_OUTCOME,
+          peers,
+          openTimestamp,
+          uint8(0),              // dataSourceRaw (AUTO)
+          uint8(0)               // binanceIntervalRaw (1m)
+        );
+      }
+      return data;
+    }
+
+    revert("unknown EVENT_RULE_TYPE");
   }
 
   /// @dev Simple comma splitter. Allocates worst-case array and fills.

--- a/script/CreateSportsMarket.s.sol
+++ b/script/CreateSportsMarket.s.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Script, console} from "forge-std/Script.sol";
+import {PredictionMarketV3ManagerCLOB} from "../contracts/PredictionMarketV3ManagerCLOB.sol";
+
+/// @notice Creates a CLOB market backed by the SportsCREOracle.
+///
+///         Required env vars:
+///           PRIVATE_KEY         — signer (must have MARKET_ADMIN_ROLE)
+///           CLOB_MANAGER        — manager address
+///           CLOB_FEE_MODULE     — fee module address
+///           SPORTS_ORACLE       — SportsCREOracle address
+///           CLOSES_AT           — unix timestamp when the market closes
+///           QUESTION            — market question text
+///           EXTERNAL_REF        — OddsPapi reference, e.g. "oddspapi:id1100013262926181:1:2"
+///
+///         Optional:
+///           IMAGE               — IPFS hash or URL (default: "")
+contract CreateSportsMarket is Script {
+  function run() external {
+    uint256 privateKey = vm.envUint("PRIVATE_KEY");
+    address managerAddr = vm.envAddress("CLOB_MANAGER");
+    address feeModule = vm.envAddress("CLOB_FEE_MODULE");
+    address oracle = vm.envAddress("SPORTS_ORACLE");
+    uint256 closesAt = vm.envUint("CLOSES_AT");
+    string memory question = vm.envString("QUESTION");
+    string memory externalRef = vm.envString("EXTERNAL_REF");
+    string memory image = vm.envOr("IMAGE", string(""));
+
+    bytes memory oracleData = abi.encode(externalRef);
+
+    vm.startBroadcast(privateKey);
+
+    uint256 marketId = PredictionMarketV3ManagerCLOB(managerAddr).createMarket(
+      PredictionMarketV3ManagerCLOB.CreateMarketParams({
+        closesAt: closesAt,
+        question: question,
+        image: image,
+        feeModule: feeModule,
+        oracle: oracle,
+        oracleData: oracleData
+      })
+    );
+
+    vm.stopBroadcast();
+
+    console.log("Sports market created with ID:", marketId);
+    console.log("ExternalRef:", externalRef);
+  }
+}

--- a/script/CreateSportsNegRiskEvent.s.sol
+++ b/script/CreateSportsNegRiskEvent.s.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Script, console} from "forge-std/Script.sol";
+
+import {NegRiskAdapter} from "../contracts/NegRiskAdapter.sol";
+import {PredictionMarketV3ManagerCLOB} from "../contracts/PredictionMarketV3ManagerCLOB.sol";
+
+/// @notice Creates a neg-risk event with one SportsCREOracle-backed market per outcome.
+///         Each per-outcome market is initialized with its OddsPapi externalRef.
+///
+///         Env vars (required):
+///           PRIVATE_KEY          — signer (must have MARKET_ADMIN_ROLE)
+///           NEG_RISK_ADAPTER     — NegRiskAdapter address
+///           CLOB_FEE_MODULE      — FeeModule address (used per-market)
+///           SPORTS_ORACLE        — SportsCREOracle address
+///           CLOSES_AT            — unix timestamp when all outcome markets close
+///           OUTCOMES             — comma-separated outcome names
+///           EXTERNAL_REFS        — comma-separated OddsPapi refs (one per outcome,
+///                                  same order as OUTCOMES)
+///           QUESTION             — parent event question
+///
+///         Env vars (optional):
+///           IMAGE                — IPFS hash or URL (default: "")
+contract CreateSportsNegRiskEvent is Script {
+  function run() external {
+    uint256 privateKey = vm.envUint("PRIVATE_KEY");
+    address adapterAddr = vm.envAddress("NEG_RISK_ADAPTER");
+    address feeModule = vm.envAddress("CLOB_FEE_MODULE");
+    address oracle = vm.envAddress("SPORTS_ORACLE");
+    uint256 closesAt = vm.envUint("CLOSES_AT");
+    string memory outcomesRaw = vm.envString("OUTCOMES");
+    string memory refsRaw = vm.envString("EXTERNAL_REFS");
+    string memory eventQuestion = vm.envString("QUESTION");
+    string memory image = vm.envOr("IMAGE", string(""));
+
+    string[] memory outcomes = _split(outcomesRaw, ",");
+    string[] memory refs = _split(refsRaw, ",");
+    require(outcomes.length >= 2, "need >= 2 outcomes");
+    require(outcomes.length == refs.length, "outcomes != refs count");
+
+    PredictionMarketV3ManagerCLOB.CreateMarketParams[] memory params =
+      new PredictionMarketV3ManagerCLOB.CreateMarketParams[](outcomes.length);
+
+    for (uint256 i = 0; i < outcomes.length; i++) {
+      params[i] = PredictionMarketV3ManagerCLOB.CreateMarketParams({
+        closesAt: closesAt,
+        question: outcomes[i],
+        image: image,
+        feeModule: feeModule,
+        oracle: oracle,
+        oracleData: abi.encode(refs[i])
+      });
+    }
+
+    vm.startBroadcast(privateKey);
+    bytes32 eventId = NegRiskAdapter(adapterAddr).createEvent(eventQuestion, params);
+    vm.stopBroadcast();
+
+    console.log("Sports neg-risk event created:");
+    console.logBytes32(eventId);
+    console.log("Outcomes:", outcomes.length);
+    for (uint256 i = 0; i < outcomes.length; i++) {
+      console.log("  ", outcomes[i], "->", refs[i]);
+    }
+  }
+
+  function _split(string memory str, string memory delimiter) internal pure returns (string[] memory) {
+    bytes memory strBytes = bytes(str);
+    bytes1 delim = bytes(delimiter)[0];
+
+    uint256 count = 1;
+    for (uint256 i = 0; i < strBytes.length; i++) {
+      if (strBytes[i] == delim) count++;
+    }
+
+    string[] memory parts = new string[](count);
+    uint256 partIdx;
+    uint256 start;
+
+    for (uint256 i = 0; i <= strBytes.length; i++) {
+      if (i == strBytes.length || strBytes[i] == delim) {
+        uint256 len = i - start;
+        bytes memory part = new bytes(len);
+        for (uint256 j = 0; j < len; j++) {
+          part[j] = strBytes[start + j];
+        }
+        parts[partIdx] = string(part);
+        partIdx++;
+        start = i + 1;
+      }
+    }
+
+    return parts;
+  }
+}

--- a/script/DeployCryptoCREOracle.s.sol
+++ b/script/DeployCryptoCREOracle.s.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Script, console} from "forge-std/Script.sol";
+import {AdminRegistry} from "../contracts/AdminRegistry.sol";
+import {CryptoCREOracle} from "../contracts/oracles/CryptoCREOracle.sol";
+
+/// @notice Standalone CryptoCREOracle deployment.
+///
+///         Required env vars:
+///           PRIVATE_KEY            — deployer private key
+///           ADMIN_REGISTRY         — AdminRegistry address
+///           CLOB_MANAGER           — PredictionMarketV3ManagerCLOB address
+///           KEYSTONE_FORWARDER     — Chainlink KeystoneForwarder address
+///
+///         Workflow identity (author + name) is configured POST-deploy by
+///         calling setExpectedAuthor / setExpectedWorkflowName from the
+///         MARKET_ADMIN_ROLE. Contract deploys with both expected values
+///         zero (= validation disabled) so end-to-end testing can succeed
+///         before the workflow is registered.
+contract DeployCryptoCREOracle is Script {
+  function run() external {
+    uint256 privateKey = vm.envUint("PRIVATE_KEY");
+    address registry = vm.envAddress("ADMIN_REGISTRY");
+    address managerAddr = vm.envAddress("CLOB_MANAGER");
+    address keystoneForwarder = vm.envAddress("KEYSTONE_FORWARDER");
+
+    vm.startBroadcast(privateKey);
+
+    CryptoCREOracle creOracle = new CryptoCREOracle(
+      AdminRegistry(registry),
+      managerAddr,
+      keystoneForwarder
+    );
+
+    vm.stopBroadcast();
+
+    console.log("CryptoCREOracle:", address(creOracle));
+  }
+}

--- a/script/DeployOracles.s.sol
+++ b/script/DeployOracles.s.sol
@@ -3,14 +3,20 @@ pragma solidity ^0.8.26;
 
 import {Script, console} from "forge-std/Script.sol";
 import {IRealityETH_ERC20} from "../contracts/IRealityETH_ERC20.sol";
+import {AdminRegistry} from "../contracts/AdminRegistry.sol";
 import {RealitioOracle} from "../contracts/oracles/RealitioOracle.sol";
+import {CryptoCREOracle} from "../contracts/oracles/CryptoCREOracle.sol";
 
-/// @notice Deploys the RealitioOracle for use with PredictionMarketV3ManagerCLOB.
+/// @notice Deploys oracle contracts for use with PredictionMarketV3ManagerCLOB.
 ///
 ///         Required env vars:
 ///           PRIVATE_KEY        — deployer private key
 ///           CLOB_MANAGER       — address of the deployed PredictionMarketV3ManagerCLOB
 ///           REALITIO_ERC20     — Reality.eth contract address
+///
+///         Optional CRE env vars (set to deploy CryptoCREOracle):
+///           ADMIN_REGISTRY         — AdminRegistry address
+///           KEYSTONE_FORWARDER     — Chainlink KeystoneForwarder address
 contract DeployOracles is Script {
   function run() external {
     uint256 privateKey = vm.envUint("PRIVATE_KEY");
@@ -24,8 +30,22 @@ contract DeployOracles is Script {
       managerAddr
     );
 
-    vm.stopBroadcast();
-
     console.log("RealitioOracle:", address(realitioOracle));
+
+    // Deploy CryptoCREOracle if CRE env vars are set
+    address keystoneForwarder = vm.envOr("KEYSTONE_FORWARDER", address(0));
+    if (keystoneForwarder != address(0)) {
+      address registryAddr = vm.envAddress("ADMIN_REGISTRY");
+
+      CryptoCREOracle creOracle = new CryptoCREOracle(
+        AdminRegistry(registryAddr),
+        managerAddr,
+        keystoneForwarder
+      );
+
+      console.log("CryptoCREOracle:", address(creOracle));
+    }
+
+    vm.stopBroadcast();
   }
 }

--- a/script/DeploySportsCREOracle.s.sol
+++ b/script/DeploySportsCREOracle.s.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Script, console} from "forge-std/Script.sol";
+import {AdminRegistry} from "../contracts/AdminRegistry.sol";
+import {SportsCREOracle} from "../contracts/oracles/SportsCREOracle.sol";
+
+/// @notice Standalone SportsCREOracle deployment.
+///
+///         Required env vars:
+///           PRIVATE_KEY            — deployer private key
+///           ADMIN_REGISTRY         — AdminRegistry address
+///           CLOB_MANAGER           — PredictionMarketV3ManagerCLOB address
+///           KEYSTONE_FORWARDER     — Chainlink KeystoneForwarder address
+///
+///         Workflow identity (author + name) is configured POST-deploy via
+///         setExpectedAuthor / setExpectedWorkflowName from MARKET_ADMIN_ROLE.
+contract DeploySportsCREOracle is Script {
+  function run() external {
+    uint256 privateKey = vm.envUint("PRIVATE_KEY");
+    address registry = vm.envAddress("ADMIN_REGISTRY");
+    address managerAddr = vm.envAddress("CLOB_MANAGER");
+    address keystoneForwarder = vm.envAddress("KEYSTONE_FORWARDER");
+
+    vm.startBroadcast(privateKey);
+
+    SportsCREOracle sportsOracle = new SportsCREOracle(
+      AdminRegistry(registry),
+      managerAddr,
+      keystoneForwarder
+    );
+
+    vm.stopBroadcast();
+
+    console.log("SportsCREOracle:", address(sportsOracle));
+  }
+}

--- a/script/TestDeliverSportsResult.s.sol
+++ b/script/TestDeliverSportsResult.s.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Script, console} from "forge-std/Script.sol";
+import {SportsCREOracle} from "../contracts/oracles/SportsCREOracle.sol";
+
+/// @notice Delivers a test sports result to SportsCREOracle, simulating what the
+///         CRE workflow does. Your deployer wallet must be the KeystoneForwarder.
+///
+///         Required env vars:
+///           PRIVATE_KEY       — deployer private key (must match KeystoneForwarder)
+///           SPORTS_ORACLE     — SportsCREOracle address
+///           EXTERNAL_REFS     — comma-separated externalRefs
+///                               (e.g. "oddspapi:id1100013262926181:1:2,oddspapi:id999:4:10")
+///           OUTCOME_IDS       — comma-separated outcomes (0=YES, 1=NO, -1=VOIDED)
+contract TestDeliverSportsResult is Script {
+  function run() external {
+    uint256 privateKey = vm.envUint("PRIVATE_KEY");
+    address oracleAddr = vm.envAddress("SPORTS_ORACLE");
+
+    SportsCREOracle oracle = SportsCREOracle(oracleAddr);
+
+    // Build metadata matching the oracle's expected workflow identity.
+    // Layout: [0:32] workflowId | [32:42] workflowName (bytes10) | [42:62] workflowOwner.
+    bytes32 workflowId = oracle.getExpectedWorkflowId();
+    bytes10 workflowName = oracle.getExpectedWorkflowName();
+    address workflowOwner = oracle.getExpectedAuthor();
+    bytes memory metadata = abi.encodePacked(workflowId, workflowName, workflowOwner, bytes2(0x0001));
+
+    string[] memory refs = _split(vm.envString("EXTERNAL_REFS"), ",");
+    string[] memory outcomeStrs = _split(vm.envString("OUTCOME_IDS"), ",");
+    require(refs.length == outcomeStrs.length, "length mismatch");
+
+    int256[] memory outcomes = new int256[](refs.length);
+    for (uint256 i = 0; i < refs.length; i++) {
+      outcomes[i] = vm.parseInt(outcomeStrs[i]);
+    }
+
+    bytes memory report = abi.encode(refs, outcomes);
+
+    console.log("Delivering sports results:", refs.length);
+    console.log("SportsCREOracle:", oracleAddr);
+    for (uint256 i = 0; i < refs.length; i++) {
+      console.log("  Ref:", refs[i]);
+      console.log("  Outcome:", uint256(outcomes[i]));
+    }
+
+    vm.startBroadcast(privateKey);
+    oracle.onReport(metadata, report);
+    vm.stopBroadcast();
+
+    console.log("Results delivered!");
+  }
+
+  function _split(string memory str, string memory delimiter) internal pure returns (string[] memory) {
+    bytes memory strBytes = bytes(str);
+    bytes1 delim = bytes(delimiter)[0];
+
+    uint256 count = 1;
+    for (uint256 i = 0; i < strBytes.length; i++) {
+      if (strBytes[i] == delim) count++;
+    }
+
+    string[] memory parts = new string[](count);
+    uint256 partIdx;
+    uint256 start;
+
+    for (uint256 i = 0; i <= strBytes.length; i++) {
+      if (i == strBytes.length || strBytes[i] == delim) {
+        uint256 len = i - start;
+        bytes memory part = new bytes(len);
+        for (uint256 j = 0; j < len; j++) {
+          part[j] = strBytes[start + j];
+        }
+        parts[partIdx] = string(part);
+        partIdx++;
+        start = i + 1;
+      }
+    }
+
+    return parts;
+  }
+}

--- a/scripts/create_clob_markets.sh
+++ b/scripts/create_clob_markets.sh
@@ -265,7 +265,12 @@ echo ""
 echo -e "${YELLOW}Oracle type for all markets:${NC}"
 echo "  1) No oracle (admin-only resolution)"
 echo "  2) Realitio (human-answered questions)"
-read -r -p "  Choose [1-2]: " ORACLE_CHOICE
+if [[ -n "${CRE_ORACLE:-}" ]]; then
+  echo "  3) CRE (Chainlink deterministic crypto)"
+else
+  echo -e "  3) CRE ${RED}(unavailable — CRE_ORACLE not in deploy env)${NC}"
+fi
+read -r -p "  Choose [1-3]: " ORACLE_CHOICE
 ORACLE_CHOICE="${ORACLE_CHOICE:-1}"
 
 ORACLE_TYPE="none"
@@ -280,6 +285,33 @@ case "${ORACLE_CHOICE}" in
     read -r -p "  Realitio timeout in seconds [3600]: " REALITIO_TIMEOUT_INPUT
     export REALITIO_TIMEOUT="${REALITIO_TIMEOUT_INPUT:-3600}"
     export ARBITRATOR
+    ;;
+  3)
+    ORACLE_TYPE="cre"
+    if [[ -z "${CRE_ORACLE:-}" ]]; then
+      error "CRE_ORACLE address not available. Deploy the CRE oracle first."
+      exit 1
+    fi
+    ORACLE_ADDR="${CRE_ORACLE}"
+
+    echo -e "  ${YELLOW}CRE Rule types:${NC} 0=Threshold 1=Direction 2=Change% 3=Relative 4=Hit 5=Candle"
+    read -r -p "  Rule type [1]: " RULE_TYPE
+    export RULE_TYPE="${RULE_TYPE:-1}"
+
+    read -r -p "  YES when above? (true/false) [true]: " YES_ABOVE
+    export YES_ABOVE="${YES_ABOVE:-true}"
+
+    read -r -p "  Feed ID (e.g. BTCUSDT) [BTCUSDT]: " FEED_ID
+    export FEED_ID="${FEED_ID:-BTCUSDT}"
+
+    read -r -p "  Second feed (Relative only, empty otherwise): " FEED_ID_B
+    export FEED_ID_B="${FEED_ID_B:-}"
+
+    read -r -p "  Param (price 8-dec / bps / candle interval) [0]: " PARAM
+    export PARAM="${PARAM:-0}"
+
+    read -r -p "  Open timestamp (unix, 0 for threshold/hit) [0]: " OPEN_TIMESTAMP
+    export OPEN_TIMESTAMP="${OPEN_TIMESTAMP:-0}"
     ;;
   *)
     ORACLE_TYPE="none"

--- a/test/CREReceiverBase.t.sol
+++ b/test/CREReceiverBase.t.sol
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import "forge-std/Test.sol";
+import {CREReceiverBase} from "../contracts/oracles/CREReceiverBase.sol";
+import {ICREReceiver} from "../contracts/oracles/ICREReceiver.sol";
+import {AdminRegistry} from "../contracts/AdminRegistry.sol";
+
+/// @dev Concrete subclass for testing the abstract base directly. Captures
+///      `report` bytes so we can assert that `_validate` ran before the body.
+contract MockReceiver is CREReceiverBase {
+  bytes public lastReport;
+
+  constructor(AdminRegistry _registry, address _forwarder)
+    CREReceiverBase(_registry, _forwarder) {}
+
+  function onReport(bytes calldata metadata, bytes calldata report) external override {
+    _validate(metadata);
+    lastReport = report;
+  }
+}
+
+contract CREReceiverBaseTest is Test {
+  AdminRegistry internal registry;
+  MockReceiver internal receiver;
+
+  address internal admin;
+  address internal marketAdmin = address(0xA2);
+  address internal forwarder = address(0xF0);
+  address internal other = address(0xBAD);
+
+  bytes32 internal workflowId = keccak256("workflow-id");
+  bytes10 internal workflowName = bytes10("flowname");
+  address internal workflowOwner = address(0xABCD);
+
+  function setUp() public {
+    admin = address(this);
+    registry = new AdminRegistry(admin);
+    registry.grantRole(registry.MARKET_ADMIN_ROLE(), marketAdmin);
+
+    receiver = new MockReceiver(registry, forwarder);
+  }
+
+  function _buildMetadata(bytes32 wfId, bytes10 wfName, address wfOwner)
+    internal pure returns (bytes memory)
+  {
+    return abi.encodePacked(wfId, wfName, wfOwner, bytes2(0x0001));
+  }
+
+  function _buildMetadata() internal view returns (bytes memory) {
+    return _buildMetadata(workflowId, workflowName, workflowOwner);
+  }
+
+  // ─── Constructor ─────────────────────────────────────────────────────
+
+  function testConstructorStoresForwarder() public view {
+    assertEq(receiver.getForwarder(), forwarder);
+    assertEq(address(receiver.registry()), address(registry));
+  }
+
+  function testConstructorRevertsZeroRegistry() public {
+    vm.expectRevert("registry 0");
+    new MockReceiver(AdminRegistry(address(0)), forwarder);
+  }
+
+  function testConstructorRevertsZeroForwarder() public {
+    vm.expectRevert("forwarder 0");
+    new MockReceiver(registry, address(0));
+  }
+
+  function testConstructorEmitsForwarderUpdated() public {
+    vm.expectEmit(true, true, false, false);
+    emit CREReceiverBase.ForwarderUpdated(address(0), forwarder);
+    new MockReceiver(registry, forwarder);
+  }
+
+  // ─── Default state: all expected values zero, only forwarder check active ────
+
+  function testDefaultStateNoOptIn() public {
+    assertEq(receiver.getExpectedAuthor(), address(0));
+    assertEq(receiver.getExpectedWorkflowName(), bytes10(0));
+    assertEq(receiver.getExpectedWorkflowId(), bytes32(0));
+  }
+
+  function testForwarderCheckAlwaysActive() public {
+    bytes memory report = "test-report";
+    vm.prank(other);
+    vm.expectRevert(
+      abi.encodeWithSignature("UnauthorizedSender(address,address)", other, forwarder)
+    );
+    receiver.onReport(_buildMetadata(), report);
+  }
+
+  function testForwarderAcceptedWhenNoOptInChecks() public {
+    bytes memory report = "test-report";
+    // Default state: author and name are zero, so only forwarder check runs.
+    vm.prank(forwarder);
+    receiver.onReport(_buildMetadata(), report);
+    assertEq(receiver.lastReport(), report);
+  }
+
+  // ─── Setters ─────────────────────────────────────────────────────────
+
+  function testSetForwarder() public {
+    address newForwarder = address(0xF1);
+    vm.prank(marketAdmin);
+    vm.expectEmit(true, true, false, false);
+    emit CREReceiverBase.ForwarderUpdated(forwarder, newForwarder);
+    receiver.setForwarder(newForwarder);
+    assertEq(receiver.getForwarder(), newForwarder);
+  }
+
+  function testSetForwarderZeroReverts() public {
+    vm.prank(marketAdmin);
+    vm.expectRevert("forwarder 0");
+    receiver.setForwarder(address(0));
+  }
+
+  function testSetForwarderNotAdminReverts() public {
+    vm.prank(other);
+    vm.expectRevert("not admin");
+    receiver.setForwarder(address(0xF1));
+  }
+
+  function testSetExpectedAuthor() public {
+    vm.prank(marketAdmin);
+    vm.expectEmit(true, true, false, false);
+    emit CREReceiverBase.ExpectedAuthorUpdated(address(0), workflowOwner);
+    receiver.setExpectedAuthor(workflowOwner);
+    assertEq(receiver.getExpectedAuthor(), workflowOwner);
+  }
+
+  function testSetExpectedAuthorNotAdminReverts() public {
+    vm.prank(other);
+    vm.expectRevert("not admin");
+    receiver.setExpectedAuthor(workflowOwner);
+  }
+
+  function testSetExpectedWorkflowName() public {
+    vm.prank(marketAdmin);
+    receiver.setExpectedWorkflowName(workflowName);
+    assertEq(receiver.getExpectedWorkflowName(), workflowName);
+  }
+
+  function testSetExpectedWorkflowId() public {
+    vm.prank(marketAdmin);
+    receiver.setExpectedWorkflowId(workflowId);
+    assertEq(receiver.getExpectedWorkflowId(), workflowId);
+  }
+
+  // ─── Opt-in author check ─────────────────────────────────────────────
+
+  function testAuthorCheckPassesWhenAuthorMatches() public {
+    vm.prank(marketAdmin);
+    receiver.setExpectedAuthor(workflowOwner);
+
+    vm.prank(forwarder);
+    receiver.onReport(_buildMetadata(), "ok");
+    assertEq(receiver.lastReport(), "ok");
+  }
+
+  function testAuthorCheckFailsWhenAuthorMismatch() public {
+    vm.prank(marketAdmin);
+    receiver.setExpectedAuthor(workflowOwner);
+
+    bytes memory bad = _buildMetadata(workflowId, workflowName, address(0xDEAD));
+    vm.prank(forwarder);
+    vm.expectRevert(
+      abi.encodeWithSignature(
+        "UnauthorizedAuthor(address,address)", address(0xDEAD), workflowOwner
+      )
+    );
+    receiver.onReport(bad, "x");
+  }
+
+  // ─── Opt-in workflow-name check ─────────────────────────────────────
+
+  function testNameCheckPassesWhenNameMatches() public {
+    vm.startPrank(marketAdmin);
+    receiver.setExpectedWorkflowName(workflowName);
+    vm.stopPrank();
+
+    vm.prank(forwarder);
+    receiver.onReport(_buildMetadata(), "ok");
+    assertEq(receiver.lastReport(), "ok");
+  }
+
+  function testNameCheckFailsWhenNameMismatch() public {
+    vm.startPrank(marketAdmin);
+    receiver.setExpectedWorkflowName(workflowName);
+    vm.stopPrank();
+
+    bytes10 wrongName = bytes10("WRONG");
+    bytes memory bad = _buildMetadata(workflowId, wrongName, workflowOwner);
+    vm.prank(forwarder);
+    vm.expectRevert(
+      abi.encodeWithSignature(
+        "UnauthorizedWorkflowName(bytes10,bytes10)", wrongName, workflowName
+      )
+    );
+    receiver.onReport(bad, "x");
+  }
+
+  // ─── Workflow ID is NEVER enforced ───────────────────────────────────
+
+  function testWorkflowIdNeverEnforced() public {
+    // Even when expectedWorkflowId is set to a specific value, mismatch must NOT revert.
+    vm.startPrank(marketAdmin);
+    receiver.setExpectedWorkflowId(workflowId);
+    vm.stopPrank();
+
+    bytes memory wrongIdMeta = _buildMetadata(keccak256("WRONG-ID"), workflowName, workflowOwner);
+    vm.prank(forwarder);
+    receiver.onReport(wrongIdMeta, "ok"); // should succeed
+    assertEq(receiver.lastReport(), "ok");
+  }
+
+  // ─── Forwarder rotation ──────────────────────────────────────────────
+
+  function testForwarderRotation() public {
+    address newForwarder = address(0xF1);
+    vm.prank(marketAdmin);
+    receiver.setForwarder(newForwarder);
+
+    // Old forwarder no longer accepted
+    vm.prank(forwarder);
+    vm.expectRevert(
+      abi.encodeWithSignature("UnauthorizedSender(address,address)", forwarder, newForwarder)
+    );
+    receiver.onReport(_buildMetadata(), "x");
+
+    // New forwarder accepted
+    vm.prank(newForwarder);
+    receiver.onReport(_buildMetadata(), "ok");
+    assertEq(receiver.lastReport(), "ok");
+  }
+
+  // ─── Metadata length validation ──────────────────────────────────────
+
+  function testShortMetadataReverts() public {
+    // Enable a check so the decoder runs
+    vm.prank(marketAdmin);
+    receiver.setExpectedAuthor(workflowOwner);
+
+    bytes memory shortMeta = abi.encodePacked(workflowId); // only 32 bytes, need 62+
+    vm.prank(forwarder);
+    vm.expectRevert("metadata too short");
+    receiver.onReport(shortMeta, "x");
+  }
+
+  // ─── ERC165 ──────────────────────────────────────────────────────────
+
+  function testSupportsInterface() public view {
+    assertTrue(receiver.supportsInterface(type(ICREReceiver).interfaceId));
+    assertTrue(receiver.supportsInterface(0x01ffc9a7)); // ERC165 itself
+    assertFalse(receiver.supportsInterface(0xdeadbeef));
+  }
+}

--- a/test/CryptoCREOracle.t.sol
+++ b/test/CryptoCREOracle.t.sol
@@ -1,0 +1,1034 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import "forge-std/Test.sol";
+import "../contracts/oracles/CryptoCREOracle.sol";
+import "../contracts/oracles/ICREReceiver.sol";
+import "../contracts/AdminRegistry.sol";
+import "../contracts/Outcomes.sol";
+
+/// @dev Mock manager that stores closesAt per market (mimics PredictionMarketV3ManagerCLOB).
+contract MockCLOBManager {
+  mapping(uint256 => uint256) public closesAtMap;
+
+  function setClosesAt(uint256 marketId, uint256 closesAt) external {
+    closesAtMap[marketId] = closesAt;
+  }
+
+  function getMarketClosesAt(uint256 marketId) external view returns (uint256) {
+    return closesAtMap[marketId];
+  }
+}
+
+contract CryptoCREOracleTest is Test {
+  CryptoCREOracle internal oracle;
+  MockCLOBManager internal mockManager;
+  AdminRegistry internal registry;
+
+  address internal admin;
+  address internal marketAdmin = address(0xA2);
+  address internal forwarder = address(0xF0);
+  bytes32 internal workflowId = keccak256("test-workflow");
+  bytes32 internal workflowName = bytes32(bytes10("testflow"));
+  address internal workflowOwner = address(0xABCD);
+  address internal other = address(0xBAD);
+
+  bytes32 internal BTC_FEED = keccak256("BTCUSDT");
+  bytes32 internal ETH_FEED = keccak256("ETHUSDT");
+
+  function setUp() public {
+    admin = address(this);
+    registry = new AdminRegistry(admin);
+    registry.grantRole(registry.MARKET_ADMIN_ROLE(), marketAdmin);
+
+    mockManager = new MockCLOBManager();
+    oracle = new CryptoCREOracle(
+      registry,
+      address(mockManager),
+      forwarder
+    );
+
+    // Enable opt-in checks so existing tests continue to validate them
+    vm.startPrank(marketAdmin);
+    oracle.setExpectedAuthor(workflowOwner);
+    oracle.setExpectedWorkflowName(bytes10(workflowName));
+    oracle.setExpectedWorkflowId(workflowId);
+    vm.stopPrank();
+  }
+
+  // ─── Helpers ─────────────────────────────────────────────────────────
+
+  /// @dev Builds CRE metadata with the configured workflow identity.
+  function _buildMetadata() internal view returns (bytes memory) {
+    return _buildMetadata(workflowId, workflowName, workflowOwner);
+  }
+
+  function _buildMetadata(bytes32 wfId, bytes32 wfName, address wfOwner) internal pure returns (bytes memory) {
+    // Chainlink CRE metadata layout (TIGHTLY PACKED, 64 bytes total):
+    // [0:32] workflowId (bytes32)
+    // [32:42] workflowName (bytes10)
+    // [42:62] workflowOwner (address, 20 bytes)
+    // Extra 2 bytes of padding at the end (Chainlink adds reportId to rawReport but it's before the payload, not in metadata)
+    return abi.encodePacked(wfId, bytes10(wfName), wfOwner, bytes2(0x0001));
+  }
+
+  /// @dev Delivers a single price via onReport.
+  function _deliverPrice(bytes32 feedId, uint256 timestamp, int256 close, int256 high, int256 low) internal {
+    bytes32[] memory feedIds = new bytes32[](1);
+    uint256[] memory timestamps = new uint256[](1);
+    int256[] memory closes = new int256[](1);
+    int256[] memory highs = new int256[](1);
+    int256[] memory lows = new int256[](1);
+
+    feedIds[0] = feedId;
+    timestamps[0] = timestamp;
+    closes[0] = close;
+    highs[0] = high;
+    lows[0] = low;
+
+    bytes memory report = abi.encode(feedIds, timestamps, closes, highs, lows);
+    vm.prank(forwarder);
+    oracle.onReport(_buildMetadata(), report);
+  }
+
+  /// @dev Initializes a market on the mock manager and oracle.
+  function _initMarket(
+    uint256 marketId,
+    bytes32 feedId,
+    bytes32 feedIdB,
+    uint8 rule,
+    bool yesAbove,
+    int256 param,
+    uint256 openTimestamp,
+    uint256 closesAt
+  ) internal {
+    _initMarketFull(marketId, feedId, feedIdB, rule, yesAbove, param, openTimestamp, closesAt, int256(0), uint256(0));
+  }
+
+  function _initMarketFull(
+    uint256 marketId,
+    bytes32 feedId,
+    bytes32 feedIdB,
+    uint8 rule,
+    bool yesAbove,
+    int256 param,
+    uint256 openTimestamp,
+    uint256 closesAt,
+    int256 paramB,
+    uint256 interval
+  ) internal {
+    mockManager.setClosesAt(marketId, closesAt);
+    bytes memory data = abi.encode(feedId, feedIdB, rule, yesAbove, param, openTimestamp, paramB, interval, uint8(0), uint8(0));
+    vm.prank(address(mockManager));
+    oracle.initialize(marketId, data);
+  }
+
+  // =========================================================================
+  // Constructor
+  // =========================================================================
+
+  function testConstructorSetsImmutables() public view {
+    assertEq(oracle.manager(), address(mockManager));
+    assertEq(oracle.getForwarder(), forwarder);
+    assertEq(oracle.getExpectedWorkflowId(), workflowId);
+    assertEq(oracle.getExpectedAuthor(), workflowOwner);
+    assertEq(address(oracle.registry()), address(registry));
+  }
+
+  function testConstructorZeroManagerReverts() public {
+    vm.expectRevert("manager 0");
+    new CryptoCREOracle(registry, address(0), forwarder);
+  }
+
+  function testConstructorZeroForwarderReverts() public {
+    vm.expectRevert("forwarder 0");
+    new CryptoCREOracle(registry, address(mockManager), address(0));
+  }
+
+  // =========================================================================
+  // initialize
+  // =========================================================================
+
+  function testInitializeStoresConfig() public {
+    uint256 marketId = 1;
+    uint256 closesAt = block.timestamp + 1 days;
+    _initMarket(marketId, BTC_FEED, bytes32(0), 0, true, 100000e8, 0, closesAt);
+
+    (
+      bytes32 feedId,,
+      CryptoCREOracle.RuleType rule,
+      bool yesAbove,
+      int256 param,
+      uint256 storedClosesAt,,,,
+      bool initialized,
+      ,
+    ) = oracle.marketConfigs(marketId);
+
+    assertEq(feedId, BTC_FEED);
+    assertEq(uint8(rule), 0); // THRESHOLD
+    assertTrue(yesAbove);
+    assertEq(param, 100000e8);
+    assertEq(storedClosesAt, closesAt);
+    assertTrue(initialized);
+  }
+
+  function testInitializeNotManagerReverts() public {
+    mockManager.setClosesAt(1, block.timestamp + 1 days);
+    bytes memory data = abi.encode(BTC_FEED, bytes32(0), uint8(0), true, int256(100000e8), uint256(0), int256(0), uint256(0), uint8(0), uint8(0));
+    vm.prank(other);
+    vm.expectRevert("!manager");
+    oracle.initialize(1, data);
+  }
+
+  function testInitializeDoubleInitReverts() public {
+    _initMarket(1, BTC_FEED, bytes32(0), 0, true, 100000e8, 0, block.timestamp + 1 days);
+    mockManager.setClosesAt(1, block.timestamp + 1 days);
+    bytes memory data = abi.encode(BTC_FEED, bytes32(0), uint8(0), true, int256(100000e8), uint256(0), int256(0), uint256(0), uint8(0), uint8(0));
+    vm.prank(address(mockManager));
+    vm.expectRevert("already init");
+    oracle.initialize(1, data);
+  }
+
+  function testInitializeZeroFeedReverts() public {
+    mockManager.setClosesAt(1, block.timestamp + 1 days);
+    bytes memory data = abi.encode(bytes32(0), bytes32(0), uint8(0), true, int256(100000e8), uint256(0), int256(0), uint256(0), uint8(0), uint8(0));
+    vm.prank(address(mockManager));
+    vm.expectRevert("feedId 0");
+    oracle.initialize(1, data);
+  }
+
+  function testInitializeRelativeRequiresFeedIdB() public {
+    mockManager.setClosesAt(1, block.timestamp + 1 days);
+    bytes memory data = abi.encode(BTC_FEED, bytes32(0), uint8(3), true, int256(0), uint256(100), int256(0), uint256(0), uint8(0), uint8(0));
+    vm.prank(address(mockManager));
+    vm.expectRevert("feedIdB required for RELATIVE");
+    oracle.initialize(1, data);
+  }
+
+  function testInitializeDirectionRequiresOpenTimestamp() public {
+    mockManager.setClosesAt(1, block.timestamp + 1 days);
+    bytes memory data = abi.encode(BTC_FEED, bytes32(0), uint8(1), true, int256(0), uint256(0), int256(0), uint256(0), uint8(0), uint8(0));
+    vm.prank(address(mockManager));
+    vm.expectRevert("openTimestamp required");
+    oracle.initialize(1, data);
+  }
+
+  // =========================================================================
+  // onReport
+  // =========================================================================
+
+  function testOnReportStoresPrice() public {
+    uint256 ts = 1714608000;
+    _deliverPrice(BTC_FEED, ts, 100000e8, 101000e8, 99000e8);
+
+    (int256 close, int256 high, int256 low, bool exists) = oracle.getVerifiedPrice(BTC_FEED, ts);
+    assertTrue(exists);
+    assertEq(close, 100000e8);
+    assertEq(high, 101000e8);
+    assertEq(low, 99000e8);
+  }
+
+  function testOnReportWriteOnce() public {
+    uint256 ts = 1714608000;
+    _deliverPrice(BTC_FEED, ts, 100000e8, 101000e8, 99000e8);
+    // Deliver again with different values — should be ignored
+    _deliverPrice(BTC_FEED, ts, 200000e8, 200000e8, 200000e8);
+
+    (int256 close,,,) = oracle.getVerifiedPrice(BTC_FEED, ts);
+    assertEq(close, 100000e8, "write-once: original price preserved");
+  }
+
+  function testOnReportNotForwarderReverts() public {
+    bytes32[] memory feedIds = new bytes32[](1);
+    uint256[] memory timestamps = new uint256[](1);
+    int256[] memory prices = new int256[](1);
+    feedIds[0] = BTC_FEED;
+    timestamps[0] = 100;
+    prices[0] = 100000e8;
+
+    bytes memory report = abi.encode(feedIds, timestamps, prices, prices, prices);
+    vm.prank(other);
+    vm.expectRevert(
+      abi.encodeWithSignature(
+        "UnauthorizedSender(address,address)",
+        other,
+        forwarder
+      )
+    );
+    oracle.onReport(_buildMetadata(), report);
+  }
+
+  function testOnReportWrongAuthorReverts() public {
+    bytes32[] memory feedIds = new bytes32[](1);
+    uint256[] memory timestamps = new uint256[](1);
+    int256[] memory prices = new int256[](1);
+    feedIds[0] = BTC_FEED;
+    timestamps[0] = 100;
+    prices[0] = 100000e8;
+
+    bytes memory report = abi.encode(feedIds, timestamps, prices, prices, prices);
+    bytes memory badMetadata = _buildMetadata(workflowId, workflowName, address(0xDEAD));
+    vm.prank(forwarder);
+    vm.expectRevert(
+      abi.encodeWithSignature(
+        "UnauthorizedAuthor(address,address)",
+        address(0xDEAD),
+        workflowOwner
+      )
+    );
+    oracle.onReport(badMetadata, report);
+  }
+
+  function testOnReportWrongWorkflowNameReverts() public {
+    bytes32[] memory feedIds = new bytes32[](1);
+    uint256[] memory timestamps = new uint256[](1);
+    int256[] memory prices = new int256[](1);
+    feedIds[0] = BTC_FEED;
+    timestamps[0] = 100;
+    prices[0] = 100000e8;
+
+    bytes memory report = abi.encode(feedIds, timestamps, prices, prices, prices);
+    bytes32 wrongName = bytes32(bytes10("WRONG"));
+    bytes memory badMetadata = _buildMetadata(workflowId, wrongName, workflowOwner);
+    vm.prank(forwarder);
+    vm.expectRevert(
+      abi.encodeWithSignature(
+        "UnauthorizedWorkflowName(bytes10,bytes10)",
+        bytes10(wrongName),
+        bytes10(workflowName)
+      )
+    );
+    oracle.onReport(badMetadata, report);
+  }
+
+  /// @notice Workflow ID is stored for traceability but never enforced.
+  function testOnReportWrongWorkflowIdDoesNotRevert() public {
+    bytes32[] memory feedIds = new bytes32[](1);
+    uint256[] memory timestamps = new uint256[](1);
+    int256[] memory prices = new int256[](1);
+    feedIds[0] = BTC_FEED;
+    timestamps[0] = 100;
+    prices[0] = 100000e8;
+
+    bytes memory report = abi.encode(feedIds, timestamps, prices, prices, prices);
+    bytes memory metadata = _buildMetadata(keccak256("WRONG-WF-ID"), workflowName, workflowOwner);
+    vm.prank(forwarder);
+    oracle.onReport(metadata, report); // should succeed
+    assertTrue(oracle.priceExists(keccak256(abi.encode(BTC_FEED, uint256(100)))));
+  }
+
+  function testOnReportBatchMultiplePrices() public {
+    bytes32[] memory feedIds = new bytes32[](2);
+    uint256[] memory timestamps = new uint256[](2);
+    int256[] memory closes = new int256[](2);
+    int256[] memory highs = new int256[](2);
+    int256[] memory lows = new int256[](2);
+
+    feedIds[0] = BTC_FEED; feedIds[1] = ETH_FEED;
+    timestamps[0] = 100; timestamps[1] = 100;
+    closes[0] = 100000e8; closes[1] = 3500e8;
+    highs[0] = 101000e8; highs[1] = 3600e8;
+    lows[0] = 99000e8; lows[1] = 3400e8;
+
+    bytes memory report = abi.encode(feedIds, timestamps, closes, highs, lows);
+    vm.prank(forwarder);
+    oracle.onReport(_buildMetadata(), report);
+
+    (int256 btcClose,,,) = oracle.getVerifiedPrice(BTC_FEED, 100);
+    (int256 ethClose,,,) = oracle.getVerifiedPrice(ETH_FEED, 100);
+    assertEq(btcClose, 100000e8);
+    assertEq(ethClose, 3500e8);
+  }
+
+  // =========================================================================
+  // getResult — THRESHOLD
+  // =========================================================================
+
+  function testThresholdAboveYes() public {
+    uint256 closesAt = 200;
+    _initMarket(1, BTC_FEED, bytes32(0), 0, true, 100000e8, 0, closesAt);
+    _deliverPrice(BTC_FEED, closesAt, 105000e8, 105000e8, 95000e8);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.YES));
+  }
+
+  function testThresholdAboveNo() public {
+    uint256 closesAt = 200;
+    _initMarket(1, BTC_FEED, bytes32(0), 0, true, 100000e8, 0, closesAt);
+    _deliverPrice(BTC_FEED, closesAt, 95000e8, 100000e8, 90000e8);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.NO));
+  }
+
+  function testThresholdExactMatch() public {
+    uint256 closesAt = 200;
+    // yesAbove=true, exact match -> YES ("at or above")
+    _initMarket(1, BTC_FEED, bytes32(0), 0, true, 100000e8, 0, closesAt);
+    _deliverPrice(BTC_FEED, closesAt, 100000e8, 100000e8, 100000e8);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.YES));
+  }
+
+  function testThresholdBelowYes() public {
+    uint256 closesAt = 200;
+    // yesAbove=false -> YES when close < param
+    _initMarket(1, BTC_FEED, bytes32(0), 0, false, 100000e8, 0, closesAt);
+    _deliverPrice(BTC_FEED, closesAt, 95000e8, 100000e8, 90000e8);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.YES));
+  }
+
+  function testThresholdNotResolvedWithoutPrice() public {
+    _initMarket(1, BTC_FEED, bytes32(0), 0, true, 100000e8, 0, 200);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertFalse(resolved);
+    assertEq(outcome, -2);
+  }
+
+  // =========================================================================
+  // getResult — DIRECTION
+  // =========================================================================
+
+  function testDirectionUpYes() public {
+    uint256 openTs = 100;
+    uint256 closesAt = 200;
+    _initMarket(1, BTC_FEED, bytes32(0), 1, true, 0, openTs, closesAt);
+    _deliverPrice(BTC_FEED, openTs, 100000e8, 100000e8, 100000e8);
+    _deliverPrice(BTC_FEED, closesAt, 105000e8, 106000e8, 99000e8);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.YES));
+  }
+
+  function testDirectionUpNo() public {
+    uint256 openTs = 100;
+    uint256 closesAt = 200;
+    _initMarket(1, BTC_FEED, bytes32(0), 1, true, 0, openTs, closesAt);
+    _deliverPrice(BTC_FEED, openTs, 100000e8, 100000e8, 100000e8);
+    _deliverPrice(BTC_FEED, closesAt, 95000e8, 100000e8, 90000e8);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.NO));
+  }
+
+  function testDirectionTieIsNo() public {
+    uint256 openTs = 100;
+    uint256 closesAt = 200;
+    // yesAbove=true (up), but flat -> NO
+    _initMarket(1, BTC_FEED, bytes32(0), 1, true, 0, openTs, closesAt);
+    _deliverPrice(BTC_FEED, openTs, 100000e8, 100000e8, 100000e8);
+    _deliverPrice(BTC_FEED, closesAt, 100000e8, 105000e8, 95000e8);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.NO), "tie -> NO for direction up");
+  }
+
+  function testDirectionDownYes() public {
+    uint256 openTs = 100;
+    uint256 closesAt = 200;
+    _initMarket(1, BTC_FEED, bytes32(0), 1, false, 0, openTs, closesAt);
+    _deliverPrice(BTC_FEED, openTs, 100000e8, 100000e8, 100000e8);
+    _deliverPrice(BTC_FEED, closesAt, 95000e8, 100000e8, 90000e8);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.YES));
+  }
+
+  // =========================================================================
+  // getResult — CHANGE_PCT
+  // =========================================================================
+
+  function testChangePctAboveYes() public {
+    uint256 openTs = 100;
+    uint256 closesAt = 200;
+    // param=500 bps (5%), yesAbove=true -> YES if |change| >= 5%
+    _initMarket(1, BTC_FEED, bytes32(0), 2, true, 500, openTs, closesAt);
+    _deliverPrice(BTC_FEED, openTs, 100000e8, 100000e8, 100000e8);
+    _deliverPrice(BTC_FEED, closesAt, 106000e8, 106000e8, 100000e8); // +6%
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.YES));
+  }
+
+  function testChangePctAboveNo() public {
+    uint256 openTs = 100;
+    uint256 closesAt = 200;
+    _initMarket(1, BTC_FEED, bytes32(0), 2, true, 500, openTs, closesAt);
+    _deliverPrice(BTC_FEED, openTs, 100000e8, 100000e8, 100000e8);
+    _deliverPrice(BTC_FEED, closesAt, 103000e8, 103000e8, 100000e8); // +3%
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.NO));
+  }
+
+  function testChangePctNegativeMovement() public {
+    uint256 openTs = 100;
+    uint256 closesAt = 200;
+    // |change| uses absolute value — -7% should trigger 500 bps threshold
+    _initMarket(1, BTC_FEED, bytes32(0), 2, true, 500, openTs, closesAt);
+    _deliverPrice(BTC_FEED, openTs, 100000e8, 100000e8, 100000e8);
+    _deliverPrice(BTC_FEED, closesAt, 93000e8, 100000e8, 90000e8); // -7%
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.YES), "-7% move exceeds 5% threshold");
+  }
+
+  function testChangePctStayWithinYes() public {
+    uint256 openTs = 100;
+    uint256 closesAt = 200;
+    // yesAbove=false -> YES if |change| < param
+    _initMarket(1, BTC_FEED, bytes32(0), 2, false, 500, openTs, closesAt);
+    _deliverPrice(BTC_FEED, openTs, 100000e8, 100000e8, 100000e8);
+    _deliverPrice(BTC_FEED, closesAt, 102000e8, 102000e8, 100000e8); // +2%
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.YES), "2% < 5% -> stays within");
+  }
+
+  // =========================================================================
+  // getResult — RELATIVE
+  // =========================================================================
+
+  function testRelativeAOutperformsYes() public {
+    uint256 openTs = 100;
+    uint256 closesAt = 200;
+    // BTC vs ETH, yesAbove=true -> YES if BTC outperforms
+    _initMarket(1, BTC_FEED, ETH_FEED, 3, true, 0, openTs, closesAt);
+    // BTC: 100K -> 110K (+10%), ETH: 3500 -> 3675 (+5%)
+    _deliverPrice(BTC_FEED, openTs, 100000e8, 100000e8, 100000e8);
+    _deliverPrice(BTC_FEED, closesAt, 110000e8, 110000e8, 100000e8);
+    _deliverPrice(ETH_FEED, openTs, 3500e8, 3500e8, 3500e8);
+    _deliverPrice(ETH_FEED, closesAt, 3675e8, 3675e8, 3500e8);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.YES));
+  }
+
+  function testRelativeAOutperformsNo() public {
+    uint256 openTs = 100;
+    uint256 closesAt = 200;
+    _initMarket(1, BTC_FEED, ETH_FEED, 3, true, 0, openTs, closesAt);
+    // BTC: 100K -> 103K (+3%), ETH: 3500 -> 3850 (+10%)
+    _deliverPrice(BTC_FEED, openTs, 100000e8, 100000e8, 100000e8);
+    _deliverPrice(BTC_FEED, closesAt, 103000e8, 103000e8, 100000e8);
+    _deliverPrice(ETH_FEED, openTs, 3500e8, 3500e8, 3500e8);
+    _deliverPrice(ETH_FEED, closesAt, 3850e8, 3850e8, 3500e8);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.NO));
+  }
+
+  function testRelativeTieIsNo() public {
+    uint256 openTs = 100;
+    uint256 closesAt = 200;
+    _initMarket(1, BTC_FEED, ETH_FEED, 3, true, 0, openTs, closesAt);
+    // Both +10%
+    _deliverPrice(BTC_FEED, openTs, 100000e8, 100000e8, 100000e8);
+    _deliverPrice(BTC_FEED, closesAt, 110000e8, 110000e8, 100000e8);
+    _deliverPrice(ETH_FEED, openTs, 3500e8, 3500e8, 3500e8);
+    _deliverPrice(ETH_FEED, closesAt, 3850e8, 3850e8, 3500e8);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.NO), "tie -> NO for relative");
+  }
+
+  // =========================================================================
+  // getResult — HIT
+  // =========================================================================
+
+  function testHitAboveYes() public {
+    uint256 closesAt = 200;
+    // "Will BTC hit 105K?" — yesAbove=true -> YES if high >= 105K
+    _initMarket(1, BTC_FEED, bytes32(0), 4, true, 105000e8, 0, closesAt);
+    _deliverPrice(BTC_FEED, closesAt, 102000e8, 106000e8, 98000e8); // high=106K >= 105K
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.YES));
+  }
+
+  function testHitAboveNo() public {
+    uint256 closesAt = 200;
+    _initMarket(1, BTC_FEED, bytes32(0), 4, true, 105000e8, 0, closesAt);
+    _deliverPrice(BTC_FEED, closesAt, 102000e8, 104000e8, 98000e8); // high=104K < 105K
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.NO));
+  }
+
+  function testHitBelowYes() public {
+    uint256 closesAt = 200;
+    // "Will BTC dip below 95K?" — yesAbove=false -> YES if low <= 95K
+    _initMarket(1, BTC_FEED, bytes32(0), 4, false, 95000e8, 0, closesAt);
+    _deliverPrice(BTC_FEED, closesAt, 98000e8, 102000e8, 94000e8); // low=94K ≤ 95K
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.YES));
+  }
+
+  function testHitBelowNo() public {
+    uint256 closesAt = 200;
+    _initMarket(1, BTC_FEED, bytes32(0), 4, false, 95000e8, 0, closesAt);
+    _deliverPrice(BTC_FEED, closesAt, 98000e8, 102000e8, 96000e8); // low=96K > 95K
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.NO));
+  }
+
+  // =========================================================================
+  // getResult — CANDLE
+  // =========================================================================
+
+  function testCandleMoreGreenYes() public {
+    // 4 candles of 100s each: openTs=100, closesAt=500, interval=100
+    // Candle 1 (100->200): 100K->105K (green)
+    // Candle 2 (200->300): 105K->103K (red)
+    // Candle 3 (300->400): 103K->108K (green)
+    // Candle 4 (400->500): 108K->110K (green)
+    // Result: 3 green, 1 red -> YES (yesAbove=true means more green)
+    _initMarket(1, BTC_FEED, bytes32(0), 5, true, 100, 100, 500); // rule=5=CANDLE, param=100s interval
+
+    _deliverPrice(BTC_FEED, 100, 100000e8, 100000e8, 100000e8);
+    _deliverPrice(BTC_FEED, 200, 105000e8, 105000e8, 100000e8);
+    _deliverPrice(BTC_FEED, 300, 103000e8, 106000e8, 102000e8);
+    _deliverPrice(BTC_FEED, 400, 108000e8, 108000e8, 103000e8);
+    _deliverPrice(BTC_FEED, 500, 110000e8, 111000e8, 107000e8);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.YES), "3 green > 1 red");
+  }
+
+  function testCandleMoreRedNo() public {
+    // yesAbove=true, but more red candles -> NO
+    _initMarket(1, BTC_FEED, bytes32(0), 5, true, 100, 100, 500);
+
+    _deliverPrice(BTC_FEED, 100, 100000e8, 100000e8, 100000e8);
+    _deliverPrice(BTC_FEED, 200, 98000e8, 100000e8, 97000e8);   // red
+    _deliverPrice(BTC_FEED, 300, 96000e8, 98000e8, 95000e8);    // red
+    _deliverPrice(BTC_FEED, 400, 97000e8, 97000e8, 95000e8);    // green
+    _deliverPrice(BTC_FEED, 500, 94000e8, 97000e8, 93000e8);    // red
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.NO), "1 green < 3 red");
+  }
+
+  function testCandleMoreRedYesWhenFlipped() public {
+    // yesAbove=false means "YES if more red candles"
+    _initMarket(1, BTC_FEED, bytes32(0), 5, false, 100, 100, 500);
+
+    _deliverPrice(BTC_FEED, 100, 100000e8, 100000e8, 100000e8);
+    _deliverPrice(BTC_FEED, 200, 98000e8, 100000e8, 97000e8);   // red
+    _deliverPrice(BTC_FEED, 300, 96000e8, 98000e8, 95000e8);    // red
+    _deliverPrice(BTC_FEED, 400, 97000e8, 97000e8, 95000e8);    // green
+    _deliverPrice(BTC_FEED, 500, 94000e8, 97000e8, 93000e8);    // red
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.YES), "yesAbove=false, 3 red > 1 green -> YES");
+  }
+
+  function testCandleTieIsNo() public {
+    // 2 candles: 1 green, 1 red -> tie -> NO
+    _initMarket(1, BTC_FEED, bytes32(0), 5, true, 100, 100, 300);
+
+    _deliverPrice(BTC_FEED, 100, 100000e8, 100000e8, 100000e8);
+    _deliverPrice(BTC_FEED, 200, 105000e8, 105000e8, 100000e8); // green
+    _deliverPrice(BTC_FEED, 300, 103000e8, 106000e8, 102000e8); // red
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.NO), "1 green == 1 red -> tie -> NO");
+  }
+
+  function testCandleFlatCandlesIgnored() public {
+    // 3 candles: 1 green, 1 flat, 1 red -> green=1, red=1 -> tie -> NO
+    _initMarket(1, BTC_FEED, bytes32(0), 5, true, 100, 100, 400);
+
+    _deliverPrice(BTC_FEED, 100, 100000e8, 100000e8, 100000e8);
+    _deliverPrice(BTC_FEED, 200, 105000e8, 105000e8, 100000e8); // green
+    _deliverPrice(BTC_FEED, 300, 105000e8, 106000e8, 104000e8); // flat (same close)
+    _deliverPrice(BTC_FEED, 400, 103000e8, 105000e8, 102000e8); // red
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.NO), "1 green, 1 flat, 1 red -> tie -> NO");
+  }
+
+  function testCandleNotResolvedIfMissingPrice() public {
+    _initMarket(1, BTC_FEED, bytes32(0), 5, true, 100, 100, 300);
+    // Only deliver first price, missing the rest
+    _deliverPrice(BTC_FEED, 100, 100000e8, 100000e8, 100000e8);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertFalse(resolved);
+    assertEq(outcome, -2);
+  }
+
+  // =========================================================================
+  // getResult — FIRST_TO_HIT
+  // =========================================================================
+
+  function testFirstToHitAboveFirst() public {
+    // "Will BTC hit $105K or dip to $90K first?" interval=100s, period 100-500
+    // Sub-intervals: [100-200], [200-300], [300-400], [400-500]
+    _initMarketFull(1, BTC_FEED, bytes32(0), 6, true, 105000e8, 100, 500, 90000e8, 100);
+
+    // Interval 1 (100-200): high=103K, low=99K — neither hit
+    _deliverPrice(BTC_FEED, 200, 101000e8, 103000e8, 99000e8);
+    // Interval 2 (200-300): high=106K, low=100K — above hit! below not hit
+    _deliverPrice(BTC_FEED, 300, 104000e8, 106000e8, 100000e8);
+    // Don't need to deliver more — should resolve at interval 2
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.YES), "above ($105K) hit first");
+  }
+
+  function testFirstToHitBelowFirst() public {
+    _initMarketFull(1, BTC_FEED, bytes32(0), 6, true, 105000e8, 100, 500, 90000e8, 100);
+
+    // Interval 1 (100-200): high=102K, low=89K — below hit! above not hit
+    _deliverPrice(BTC_FEED, 200, 91000e8, 102000e8, 89000e8);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.NO), "below ($90K) hit first");
+  }
+
+  function testFirstToHitBothInSameIntervalResolvedInNext() public {
+    _initMarketFull(1, BTC_FEED, bytes32(0), 6, true, 105000e8, 100, 500, 90000e8, 100);
+
+    // Interval 1 (100-200): high=106K, low=89K — both hit! inconclusive
+    _deliverPrice(BTC_FEED, 200, 95000e8, 106000e8, 89000e8);
+    // Interval 2 (200-300): high=104K, low=88K — only below hit
+    _deliverPrice(BTC_FEED, 300, 92000e8, 104000e8, 88000e8);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.NO), "both hit in interval 1, below only in interval 2");
+  }
+
+  function testFirstToHitNeitherHitNotResolved() public {
+    _initMarketFull(1, BTC_FEED, bytes32(0), 6, true, 105000e8, 100, 300, 90000e8, 100);
+
+    // Interval 1 (100-200): high=103K, low=92K — neither hit
+    _deliverPrice(BTC_FEED, 200, 100000e8, 103000e8, 92000e8);
+    // Interval 2 (200-300): high=104K, low=91K — neither hit
+    _deliverPrice(BTC_FEED, 300, 100000e8, 104000e8, 91000e8);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertFalse(resolved);
+    assertEq(outcome, -2);
+  }
+
+  function testFirstToHitMissingPriceNotResolved() public {
+    _initMarketFull(1, BTC_FEED, bytes32(0), 6, true, 105000e8, 100, 300, 90000e8, 100);
+    // Don't deliver any prices
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertFalse(resolved);
+    assertEq(outcome, -2);
+  }
+
+  // =========================================================================
+  // getResult — not initialized
+  // =========================================================================
+
+  function testGetResultNotInitializedReverts() public {
+    vm.expectRevert("!init");
+    oracle.getResult(999);
+  }
+
+  // =========================================================================
+  // Price sharing across markets
+  // =========================================================================
+
+  function testPriceSharingAcrossMarkets() public {
+    uint256 closesAt = 200;
+    // Two markets with same feed+closesAt but different thresholds
+    _initMarket(1, BTC_FEED, bytes32(0), 0, true, 100000e8, 0, closesAt);
+    _initMarket(2, BTC_FEED, bytes32(0), 0, true, 110000e8, 0, closesAt);
+
+    // One price delivery serves both
+    _deliverPrice(BTC_FEED, closesAt, 105000e8, 105000e8, 95000e8);
+
+    (int256 outcome1, bool resolved1) = oracle.getResult(1);
+    (int256 outcome2, bool resolved2) = oracle.getResult(2);
+
+    assertTrue(resolved1);
+    assertTrue(resolved2);
+    assertEq(outcome1, int256(Outcomes.YES), "105K >= 100K");
+    assertEq(outcome2, int256(Outcomes.NO), "105K < 110K");
+  }
+
+  // =========================================================================
+  // RANGE_BUCKET (rule 7)
+  // =========================================================================
+
+  function testRangeBucketYes() public {
+    uint256 closesAt = 200;
+    // bucket [100K, 110K)
+    _initMarketFull(1, BTC_FEED, bytes32(0), 7, true, 100_000e8, 0, closesAt, 110_000e8, 0);
+    _deliverPrice(BTC_FEED, closesAt, 105_000e8, 105_000e8, 105_000e8);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.YES));
+  }
+
+  function testRangeBucketNoBelow() public {
+    uint256 closesAt = 200;
+    _initMarketFull(1, BTC_FEED, bytes32(0), 7, true, 100_000e8, 0, closesAt, 110_000e8, 0);
+    _deliverPrice(BTC_FEED, closesAt, 99_999e8, 99_999e8, 99_999e8);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.NO));
+  }
+
+  function testRangeBucketNoAtUpperBound() public {
+    uint256 closesAt = 200;
+    _initMarketFull(1, BTC_FEED, bytes32(0), 7, true, 100_000e8, 0, closesAt, 110_000e8, 0);
+    // Half-open: price == upperBound is NO (belongs to next bucket)
+    _deliverPrice(BTC_FEED, closesAt, 110_000e8, 110_000e8, 110_000e8);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.NO));
+  }
+
+  function testRangeBucketYesAtLowerBound() public {
+    uint256 closesAt = 200;
+    _initMarketFull(1, BTC_FEED, bytes32(0), 7, true, 100_000e8, 0, closesAt, 110_000e8, 0);
+    // Half-open: price == lowerBound is YES
+    _deliverPrice(BTC_FEED, closesAt, 100_000e8, 100_000e8, 100_000e8);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.YES));
+  }
+
+  function testRangeBucketNotResolvedWithoutFeed() public {
+    uint256 closesAt = 200;
+    _initMarketFull(1, BTC_FEED, bytes32(0), 7, true, 100_000e8, 0, closesAt, 110_000e8, 0);
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertFalse(resolved);
+    assertEq(outcome, int256(-2));
+  }
+
+  function testRangeBucketRequiresUpperGreaterThanLower() public {
+    mockManager.setClosesAt(1, 200);
+    bytes memory data = abi.encode(BTC_FEED, bytes32(0), uint8(7), true, int256(110_000e8), uint256(0), int256(100_000e8), uint256(0), uint8(0), uint8(0));
+    vm.prank(address(mockManager));
+    vm.expectRevert("upperBound > lowerBound");
+    oracle.initialize(1, data);
+  }
+
+  // =========================================================================
+  // RANGE_BUCKET_HIGH (rule 9) — for HIT_MILESTONES outcomes
+  // =========================================================================
+
+  function testRangeBucketHighReadsHighPrice() public {
+    uint256 closesAt = 200;
+    // bucket [100K, 110K) on highPrice
+    _initMarketFull(1, BTC_FEED, bytes32(0), 9, true, 100_000e8, 0, closesAt, 110_000e8, 0);
+    // close=99K but high=105K → high is in range → YES
+    _deliverPrice(BTC_FEED, closesAt, 99_000e8, 105_000e8, 90_000e8);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.YES));
+  }
+
+  function testRangeBucketHighOutOfRange() public {
+    uint256 closesAt = 200;
+    _initMarketFull(1, BTC_FEED, bytes32(0), 9, true, 100_000e8, 0, closesAt, 110_000e8, 0);
+    // high=120K — above upper → NO
+    _deliverPrice(BTC_FEED, closesAt, 115_000e8, 120_000e8, 90_000e8);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.NO));
+  }
+
+  // =========================================================================
+  // BEST_PERFORMER_OUTCOME (rule 8)
+  // =========================================================================
+
+  function _initBestPerformerMarket(
+    uint256 marketId,
+    bytes32 myFeedId,
+    bytes32[] memory peers,
+    uint256 openTimestamp,
+    uint256 closesAt
+  ) internal {
+    mockManager.setClosesAt(marketId, closesAt);
+    bytes memory data = abi.encode(myFeedId, bytes32(0), uint8(8), peers, openTimestamp, uint8(0), uint8(0));
+    vm.prank(address(mockManager));
+    oracle.initialize(marketId, data);
+  }
+
+  function testBestPerformerOutcomeUniqueWinner() public {
+    bytes32 SOL = keccak256("SOLUSDT");
+    bytes32 DOGE = keccak256("DOGEUSDT");
+
+    uint256 openTs = 100;
+    uint256 closeTs = 200;
+
+    // Market 1 = BTC. Peers: ETH, SOL, DOGE.
+    bytes32[] memory peers = new bytes32[](3);
+    peers[0] = ETH_FEED;
+    peers[1] = SOL;
+    peers[2] = DOGE;
+    _initBestPerformerMarket(1, BTC_FEED, peers, openTs, closeTs);
+
+    // Deliver opens (all at $100 for simple math) and closes:
+    //   BTC: 100 → 130 (+30%)
+    //   ETH: 100 → 110 (+10%)
+    //   SOL: 100 → 120 (+20%)
+    //   DOGE: 100 → 105 (+5%)
+    _deliverPrice(BTC_FEED, openTs, 100e8, 100e8, 100e8);
+    _deliverPrice(BTC_FEED, closeTs, 130e8, 130e8, 130e8);
+    _deliverPrice(ETH_FEED, openTs, 100e8, 100e8, 100e8);
+    _deliverPrice(ETH_FEED, closeTs, 110e8, 110e8, 110e8);
+    _deliverPrice(SOL, openTs, 100e8, 100e8, 100e8);
+    _deliverPrice(SOL, closeTs, 120e8, 120e8, 120e8);
+    _deliverPrice(DOGE, openTs, 100e8, 100e8, 100e8);
+    _deliverPrice(DOGE, closeTs, 105e8, 105e8, 105e8);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.YES), "BTC wins uniquely");
+  }
+
+  function testBestPerformerOutcomeNotWinner() public {
+    uint256 openTs = 100;
+    uint256 closeTs = 200;
+
+    // Market 2 = ETH (less performer). Peers: BTC.
+    bytes32[] memory peers = new bytes32[](1);
+    peers[0] = BTC_FEED;
+    _initBestPerformerMarket(2, ETH_FEED, peers, openTs, closeTs);
+
+    _deliverPrice(BTC_FEED, openTs, 100e8, 100e8, 100e8);
+    _deliverPrice(BTC_FEED, closeTs, 130e8, 130e8, 130e8);
+    _deliverPrice(ETH_FEED, openTs, 100e8, 100e8, 100e8);
+    _deliverPrice(ETH_FEED, closeTs, 110e8, 110e8, 110e8);
+
+    (int256 outcome, bool resolved) = oracle.getResult(2);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.NO), "ETH loses to BTC");
+  }
+
+  function testBestPerformerOutcomeTieAtTop() public {
+    uint256 openTs = 100;
+    uint256 closeTs = 200;
+
+    bytes32[] memory peers = new bytes32[](1);
+    peers[0] = ETH_FEED;
+    _initBestPerformerMarket(1, BTC_FEED, peers, openTs, closeTs);
+
+    // Identical % change → tie → BTC market resolves NO (strict comparison).
+    _deliverPrice(BTC_FEED, openTs, 100e8, 100e8, 100e8);
+    _deliverPrice(BTC_FEED, closeTs, 110e8, 110e8, 110e8);
+    _deliverPrice(ETH_FEED, openTs, 200e8, 200e8, 200e8);
+    _deliverPrice(ETH_FEED, closeTs, 220e8, 220e8, 220e8);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.NO), "tie -> NO");
+  }
+
+  function testBestPerformerOutcomeNotReadyMissingPeerOpen() public {
+    uint256 openTs = 100;
+    uint256 closeTs = 200;
+
+    bytes32[] memory peers = new bytes32[](1);
+    peers[0] = ETH_FEED;
+    _initBestPerformerMarket(1, BTC_FEED, peers, openTs, closeTs);
+
+    _deliverPrice(BTC_FEED, openTs, 100e8, 100e8, 100e8);
+    _deliverPrice(BTC_FEED, closeTs, 130e8, 130e8, 130e8);
+    _deliverPrice(ETH_FEED, closeTs, 110e8, 110e8, 110e8);
+    // Peer's open price is missing.
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertFalse(resolved);
+    assertEq(outcome, int256(-2));
+  }
+
+  function testBestPerformerOutcomeMyOpenZero() public {
+    uint256 openTs = 100;
+    uint256 closeTs = 200;
+
+    bytes32[] memory peers = new bytes32[](1);
+    peers[0] = ETH_FEED;
+    _initBestPerformerMarket(1, BTC_FEED, peers, openTs, closeTs);
+
+    // My open price is zero — can't compute %change → automatic NO
+    _deliverPrice(BTC_FEED, openTs, 0, 0, 0);
+    _deliverPrice(BTC_FEED, closeTs, 130e8, 130e8, 130e8);
+    _deliverPrice(ETH_FEED, openTs, 100e8, 100e8, 100e8);
+    _deliverPrice(ETH_FEED, closeTs, 110e8, 110e8, 110e8);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.NO));
+  }
+
+  function testBestPerformerOutcomeRejectsSelfAsPeer() public {
+    bytes32[] memory peers = new bytes32[](1);
+    peers[0] = BTC_FEED; // same as myFeedId
+    mockManager.setClosesAt(1, 200);
+    bytes memory data = abi.encode(BTC_FEED, bytes32(0), uint8(8), peers, uint256(100), uint8(0), uint8(0));
+    vm.prank(address(mockManager));
+    vm.expectRevert("peer = self");
+    oracle.initialize(1, data);
+  }
+
+  function testBestPerformerOutcomeRejectsEmptyPeers() public {
+    bytes32[] memory peers = new bytes32[](0);
+    mockManager.setClosesAt(1, 200);
+    bytes memory data = abi.encode(BTC_FEED, bytes32(0), uint8(8), peers, uint256(100), uint8(0), uint8(0));
+    vm.prank(address(mockManager));
+    vm.expectRevert("no peers");
+    oracle.initialize(1, data);
+  }
+
+  function testBestPerformerOutcomePeerListGetter() public {
+    bytes32[] memory peers = new bytes32[](2);
+    peers[0] = ETH_FEED;
+    peers[1] = keccak256("SOLUSDT");
+    _initBestPerformerMarket(1, BTC_FEED, peers, 100, 200);
+
+    bytes32[] memory got = oracle.getMarketPeerFeedIds(1);
+    assertEq(got.length, 2);
+    assertEq(got[0], ETH_FEED);
+    assertEq(got[1], peers[1]);
+  }
+}

--- a/test/SportsCREOracle.t.sol
+++ b/test/SportsCREOracle.t.sol
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import "forge-std/Test.sol";
+import "../contracts/oracles/SportsCREOracle.sol";
+import "../contracts/oracles/ICREReceiver.sol";
+import "../contracts/AdminRegistry.sol";
+import "../contracts/Outcomes.sol";
+
+/// @dev Mock manager that stores closesAt per market.
+contract MockSportsManager {
+  mapping(uint256 => uint256) public closesAtMap;
+
+  function setClosesAt(uint256 marketId, uint256 closesAt) external {
+    closesAtMap[marketId] = closesAt;
+  }
+
+  function getMarketClosesAt(uint256 marketId) external view returns (uint256) {
+    return closesAtMap[marketId];
+  }
+}
+
+contract SportsCREOracleTest is Test {
+  SportsCREOracle internal oracle;
+  MockSportsManager internal mockManager;
+  AdminRegistry internal registry;
+
+  address internal admin;
+  address internal marketAdmin = address(0xA2);
+  address internal forwarder = address(0xF0);
+  bytes32 internal workflowId = keccak256("sports-workflow");
+  bytes32 internal workflowName = bytes32(bytes10("sportsflow"));
+  address internal workflowOwner = address(0xABCD);
+  address internal other = address(0xBAD);
+
+  string internal REF_NBA = "oddspapi:id1100013262926181:1:2";
+  string internal REF_NFL = "oddspapi:id999:4:10";
+
+  function setUp() public {
+    admin = address(this);
+    registry = new AdminRegistry(admin);
+    registry.grantRole(registry.MARKET_ADMIN_ROLE(), marketAdmin);
+
+    mockManager = new MockSportsManager();
+    oracle = new SportsCREOracle(
+      registry,
+      address(mockManager),
+      forwarder
+    );
+
+    // Enable opt-in checks
+    vm.startPrank(marketAdmin);
+    oracle.setExpectedAuthor(workflowOwner);
+    oracle.setExpectedWorkflowName(bytes10(workflowName));
+    oracle.setExpectedWorkflowId(workflowId);
+    vm.stopPrank();
+  }
+
+  // ─── Helpers ─────────────────────────────────────────────────────────
+
+  function _buildMetadata() internal view returns (bytes memory) {
+    return _buildMetadata(workflowId, workflowName, workflowOwner);
+  }
+
+  function _buildMetadata(bytes32 wfId, bytes32 wfName, address wfOwner) internal pure returns (bytes memory) {
+    // Chainlink CRE metadata layout (TIGHTLY PACKED, 64 bytes total):
+    // [0:32] workflowId, [32:42] workflowName (10 bytes), [42:62] workflowOwner (20 bytes)
+    return abi.encodePacked(wfId, bytes10(wfName), wfOwner, bytes2(0x0001));
+  }
+
+  function _deliverResult(string memory externalRef, int256 outcomeId) internal {
+    string[] memory refs = new string[](1);
+    int256[] memory outcomes = new int256[](1);
+    refs[0] = externalRef;
+    outcomes[0] = outcomeId;
+    bytes memory report = abi.encode(refs, outcomes);
+    vm.prank(forwarder);
+    oracle.onReport(_buildMetadata(), report);
+  }
+
+  function _initMarket(uint256 marketId, string memory externalRef, uint256 closesAt) internal {
+    mockManager.setClosesAt(marketId, closesAt);
+    bytes memory data = abi.encode(externalRef);
+    vm.prank(address(mockManager));
+    oracle.initialize(marketId, data);
+  }
+
+  // =========================================================================
+  // Constructor
+  // =========================================================================
+
+  function testConstructorSetsImmutables() public view {
+    assertEq(oracle.manager(), address(mockManager));
+    assertEq(oracle.getForwarder(), forwarder);
+    assertEq(oracle.getExpectedWorkflowId(), workflowId);
+    assertEq(oracle.getExpectedAuthor(), workflowOwner);
+    assertEq(address(oracle.registry()), address(registry));
+  }
+
+  function testConstructorZeroManagerReverts() public {
+    vm.expectRevert("manager 0");
+    new SportsCREOracle(registry, address(0), forwarder);
+  }
+
+  function testConstructorZeroForwarderReverts() public {
+    vm.expectRevert("forwarder 0");
+    new SportsCREOracle(registry, address(mockManager), address(0));
+  }
+
+  // =========================================================================
+  // initialize
+  // =========================================================================
+
+  function testInitializeStoresConfig() public {
+    uint256 marketId = 1;
+    uint256 closesAt = block.timestamp + 1 days;
+    _initMarket(marketId, REF_NBA, closesAt);
+
+    (string memory ref, bytes32 refHash) = oracle.getMarketExternalRef(marketId);
+    assertEq(ref, REF_NBA);
+    assertEq(refHash, keccak256(bytes(REF_NBA)));
+  }
+
+  function testInitializeNotManagerReverts() public {
+    mockManager.setClosesAt(1, block.timestamp + 1 days);
+    bytes memory data = abi.encode(REF_NBA);
+    vm.prank(other);
+    vm.expectRevert("!manager");
+    oracle.initialize(1, data);
+  }
+
+  function testInitializeDoubleInitReverts() public {
+    _initMarket(1, REF_NBA, block.timestamp + 1 days);
+    bytes memory data = abi.encode(REF_NBA);
+    vm.prank(address(mockManager));
+    vm.expectRevert("already init");
+    oracle.initialize(1, data);
+  }
+
+  function testInitializeEmptyRefReverts() public {
+    mockManager.setClosesAt(1, block.timestamp + 1 days);
+    bytes memory data = abi.encode("");
+    vm.prank(address(mockManager));
+    vm.expectRevert("externalRef required");
+    oracle.initialize(1, data);
+  }
+
+  // =========================================================================
+  // onReport
+  // =========================================================================
+
+  function testOnReportStoresOutcome() public {
+    _deliverResult(REF_NBA, int256(Outcomes.YES));
+
+    bytes32 refHash = keccak256(bytes(REF_NBA));
+    assertTrue(oracle.outcomeResolved(refHash));
+    assertEq(oracle.resolvedOutcomes(refHash), int256(Outcomes.YES));
+  }
+
+  function testOnReportWriteOnce() public {
+    _deliverResult(REF_NBA, int256(Outcomes.YES));
+    // Attempt to overwrite with NO
+    _deliverResult(REF_NBA, int256(Outcomes.NO));
+
+    bytes32 refHash = keccak256(bytes(REF_NBA));
+    assertEq(oracle.resolvedOutcomes(refHash), int256(Outcomes.YES), "write-once: original preserved");
+  }
+
+  function testOnReportNotForwarderReverts() public {
+    string[] memory refs = new string[](1);
+    int256[] memory outcomes = new int256[](1);
+    refs[0] = REF_NBA;
+    outcomes[0] = int256(Outcomes.YES);
+    bytes memory report = abi.encode(refs, outcomes);
+
+    vm.prank(other);
+    vm.expectRevert(
+      abi.encodeWithSignature(
+        "UnauthorizedSender(address,address)",
+        other,
+        forwarder
+      )
+    );
+    oracle.onReport(_buildMetadata(), report);
+  }
+
+  function testOnReportWrongAuthorReverts() public {
+    string[] memory refs = new string[](1);
+    int256[] memory outcomes = new int256[](1);
+    refs[0] = REF_NBA;
+    outcomes[0] = int256(Outcomes.YES);
+    bytes memory report = abi.encode(refs, outcomes);
+
+    bytes memory badMetadata = _buildMetadata(workflowId, workflowName, address(0xDEAD));
+    vm.prank(forwarder);
+    vm.expectRevert(
+      abi.encodeWithSignature(
+        "UnauthorizedAuthor(address,address)",
+        address(0xDEAD),
+        workflowOwner
+      )
+    );
+    oracle.onReport(badMetadata, report);
+  }
+
+  /// @notice Workflow ID is stored for traceability but never enforced.
+  function testOnReportWrongWorkflowIdDoesNotRevert() public {
+    string[] memory refs = new string[](1);
+    int256[] memory outcomes = new int256[](1);
+    refs[0] = REF_NBA;
+    outcomes[0] = int256(Outcomes.YES);
+    bytes memory report = abi.encode(refs, outcomes);
+
+    bytes memory metadata = _buildMetadata(keccak256("WRONG-WF-ID"), workflowName, workflowOwner);
+    vm.prank(forwarder);
+    oracle.onReport(metadata, report); // should succeed
+    assertTrue(oracle.outcomeResolved(keccak256(bytes(REF_NBA))));
+  }
+
+  function testOnReportInvalidOutcomeReverts() public {
+    string[] memory refs = new string[](1);
+    int256[] memory outcomes = new int256[](1);
+    refs[0] = REF_NBA;
+    outcomes[0] = 999; // not YES/NO/VOIDED
+    bytes memory report = abi.encode(refs, outcomes);
+
+    vm.prank(forwarder);
+    vm.expectRevert("invalid outcomeId");
+    oracle.onReport(_buildMetadata(), report);
+  }
+
+  function testOnReportBatchMultiple() public {
+    string[] memory refs = new string[](2);
+    int256[] memory outcomes = new int256[](2);
+    refs[0] = REF_NBA; refs[1] = REF_NFL;
+    outcomes[0] = int256(Outcomes.YES); outcomes[1] = int256(Outcomes.NO);
+    bytes memory report = abi.encode(refs, outcomes);
+
+    vm.prank(forwarder);
+    oracle.onReport(_buildMetadata(), report);
+
+    assertEq(oracle.resolvedOutcomes(keccak256(bytes(REF_NBA))), int256(Outcomes.YES));
+    assertEq(oracle.resolvedOutcomes(keccak256(bytes(REF_NFL))), int256(Outcomes.NO));
+  }
+
+  function testOnReportVoidedOutcome() public {
+    _deliverResult(REF_NBA, Outcomes.VOIDED);
+    bytes32 refHash = keccak256(bytes(REF_NBA));
+    assertEq(oracle.resolvedOutcomes(refHash), Outcomes.VOIDED);
+  }
+
+  // =========================================================================
+  // getResult
+  // =========================================================================
+
+  function testGetResultNotInitializedReverts() public {
+    vm.expectRevert("!init");
+    oracle.getResult(999);
+  }
+
+  function testGetResultBeforeReport() public {
+    _initMarket(1, REF_NBA, block.timestamp + 1 days);
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertEq(outcome, -2);
+    assertFalse(resolved);
+  }
+
+  function testGetResultYes() public {
+    _initMarket(1, REF_NBA, block.timestamp + 1 days);
+    _deliverResult(REF_NBA, int256(Outcomes.YES));
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.YES));
+  }
+
+  function testGetResultNo() public {
+    _initMarket(1, REF_NBA, block.timestamp + 1 days);
+    _deliverResult(REF_NBA, int256(Outcomes.NO));
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, int256(Outcomes.NO));
+  }
+
+  function testGetResultVoided() public {
+    _initMarket(1, REF_NBA, block.timestamp + 1 days);
+    _deliverResult(REF_NBA, Outcomes.VOIDED);
+
+    (int256 outcome, bool resolved) = oracle.getResult(1);
+    assertTrue(resolved);
+    assertEq(outcome, Outcomes.VOIDED);
+  }
+
+  // =========================================================================
+  // Shared externalRef across markets
+  // =========================================================================
+
+  function testSharedRefResolvesBothMarkets() public {
+    // Two markets with the same externalRef (rare but possible)
+    _initMarket(1, REF_NBA, block.timestamp + 1 days);
+    _initMarket(2, REF_NBA, block.timestamp + 2 days);
+
+    // One delivery resolves both
+    _deliverResult(REF_NBA, int256(Outcomes.YES));
+
+    (int256 outcome1, bool resolved1) = oracle.getResult(1);
+    (int256 outcome2, bool resolved2) = oracle.getResult(2);
+
+    assertTrue(resolved1);
+    assertTrue(resolved2);
+    assertEq(outcome1, int256(Outcomes.YES));
+    assertEq(outcome2, int256(Outcomes.YES));
+  }
+
+  // =========================================================================
+  // ERC165
+  // =========================================================================
+
+  function testSupportsICREReceiverInterface() public view {
+    assertTrue(oracle.supportsInterface(type(ICREReceiver).interfaceId));
+  }
+
+  function testSupportsERC165() public view {
+    assertTrue(oracle.supportsInterface(0x01ffc9a7));
+  }
+
+  function testDoesNotSupportRandomInterface() public view {
+    assertFalse(oracle.supportsInterface(0x12345678));
+  }
+}


### PR DESCRIPTION
# Chainlink CRE Integration for Deterministic Crypto & Sports Markets

### Architecture

```
CRE Workflow (Chainlink DON)
    │
    │ onReport() — verified data from forwarder
    ▼
┌───────────────────────────┐    ┌───────────────────────────┐
│ CryptoCREOracle           │    │ SportsCREOracle           │
│ (IMarketOracle+IReceiver) │    │ (IMarketOracle+IReceiver) │
│ Computes outcome on-chain │    │ Stores DON-reported result│
└───────────────────────────┘    └───────────────────────────┘
            │                                 │
            ▼                                 ▼
     manager.resolveMarket()           manager.resolveMarket()
        (permissionless)                (permissionless)
```

Both oracles inherit from `CREReceiverBase`, an abstract base modeled on Chainlink's `ReceiverTemplate`: forwarder check always enforced once set, opt-in author/workflow-name validation, admin-gated rotation via `AdminRegistry`. Workflow id is stored for traceability but never enforced (it changes on every workflow recompile).

Neg-risk events are handled **without a central resolver**: each binary market in the event is configured with its own outcome-specific rule (e.g. one market per range bucket, one market per candidate token), and each resolves independently through the new `adapter.resolveEventMarket(eventId, idx)` path. The off-chain CRE workflow delivers one price/result; every market keyed by that price reuses the same stored entry.

### CryptoCREOracle — 10 rule types

| Rule | What it compares | Example |
|---|---|---|
| `THRESHOLD` | close vs fixed price | "Will BTC be above $100K at close?" |
| `DIRECTION` | close vs open | "Will BTC go up in the next 5 min?" |
| `CHANGE_PCT` | \|% change\| vs bps threshold | "Will BTC move more than 5%?" |
| `RELATIVE` | feed A's % change vs feed B's | "Will BTC outperform ETH?" |
| `HIT` | did high/low touch a target | "Will BTC hit $100K at any point?" |
| `CANDLE` | green vs red candles in a window | "More green or red 5m candles?" |
| `FIRST_TO_HIT` | which of two thresholds is crossed first | "Will BTC hit $100K or $50K first?" |
| `RANGE_BUCKET` | close in `[lower, upper)` | "Will BTC close in $90K–$100K?" (neg-risk) |
| `RANGE_BUCKET_HIGH` | high in `[lower, upper)` | "Will BTC's high reach $100K–$110K?" (neg-risk milestones) |
| `BEST_PERFORMER_OUTCOME` | myFeed strictly beats all peers' % change | "Which token performs best?" (neg-risk) |

Each rule (where directional) supports a `yesAbove` flag so the same logic covers both sides of the market.

Per-market config also includes:
- **`DataSource`** (AUTO / CHAINLINK_FEEDS / CHAINLINK_STREAMS / BINANCE) — hint to the off-chain workflow, locked at market creation so an off-chain admin can't silently re-route.
- **`BinanceInterval`** — candle width (1m … 1M) for kline reads when the source resolves to Binance.

### SportsCREOracle — generic result store

Sports resolution is inherently off-chain (OddsPapi inside DON consensus + TEE), so the oracle has **no sport-specific logic**. Markets are configured with an `externalRef` (e.g. `"oddspapi:id1100013262926181:1:2"`) which the CRE workflow parses; the workflow then delivers the winning outcome id, which the contract stores write-once. Any market type (match winner, totals, spread, player props, parlay, …) is supported because the resolution lives in the workflow.

Results are keyed by `keccak256(externalRef)` so multiple markets referencing the same event share one stored outcome.

### Price data (CryptoCREOracle)

```solidity
struct PriceData {
    int256 closePrice;  // THRESHOLD, DIRECTION, CHANGE_PCT, RELATIVE, RANGE_BUCKET, CANDLE
    int256 highPrice;   // HIT (above), RANGE_BUCKET_HIGH
    int256 lowPrice;    // HIT (below)
}
```

Prices are **write-once** (replay/manipulation guard) and keyed by `keccak256(feedId, timestamp)`.

### Security

- `onReport()` validates `msg.sender == keystoneForwarder` on both oracles.
- Opt-in metadata validation (author, workflow name) — a check is enforced only if the expected value is non-zero; workflow id is stored but not enforced.
- Forwarder / expected metadata rotation is admin-gated via `AdminRegistry`.
- Neither oracle holds any resolution role on the manager — anyone can drive resolution once the report has landed.
- `FIRST_TO_HIT` includes an on-chain sanity check (verifies the workflow-reported winner actually crossed the threshold).

## Testing

```bash
forge test                                                # 519 tests, 0 failures
forge test --match-contract CryptoCREOracleTest -vvv      # 65 tests
forge test --match-contract SportsCREOracleTest -vvv      # 24 tests
forge test --match-contract CREReceiverBaseTest -vvv      # 22 tests
```

Tested on BSC testnet with the CRE workflow simulator fetching real prices/results and delivering reports through the Chainlink KeystoneForwarder.